### PR TITLE
Update to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Build
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Run tests
@@ -55,10 +55,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.1.6
+          version: v2.8.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
           cache: true
 
       - name: Install govulncheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the kube-compare-mcp binary using Red Hat UBI Go Toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CONTAINER_TOOL ?= podman
 PLATFORM ?= linux/amd64
 
 # Linter settings
-GOLANGCI_LINT_VERSION ?= v2.1.6
+GOLANGCI_LINT_VERSION ?= v2.8.0
 
 # .PHONY declarations grouped by category
 .PHONY: all build build-darwin-arm64 build-darwin-amd64 build-linux-amd64 build-all

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ export KUBE_COMPARE_MCP_OCI_VALIDATION_TIMEOUT=60s
 
 ### Prerequisites
 
-- Go 1.24 or later
+- Go 1.25 or later
 - Access to a Kubernetes cluster (for live comparisons)
 - golangci-lint (for linting)
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sakhoury/kube-compare-mcp
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.0
 
 require (
 	github.com/google/go-containerregistry v0.20.2


### PR DESCRIPTION
Update Go version from 1.24 to 1.25 across the project:
- go.mod: bump go directive to 1.25.0
- Dockerfile: use go-toolset:1.25 base image
- CI workflow: use go-version 1.25
- Security workflow: use go-version 1.25
- README.md: update prerequisites

This enables compatibility with Kubernetes 0.35.0 dependencies which require Go 1.25.