### PR TITLE
Migrate to official MCP Go SDK (modelcontextprotocol/go-sdk v1.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ spec:
         url: http://kube-compare-mcp.kube-compare-mcp.svc.cluster.local:8080/mcp
         timeout: 60
         sseReadTimeout: 30
-        enableSSE: true
+        enableSSE: false
 ```
 
 ### Configuration for MCP Clients
@@ -685,7 +685,7 @@ make undeploy
 
 - [kube-compare](https://github.com/openshift/kube-compare) - The upstream comparison tool
 - [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server) - General Kubernetes MCP server
-- [mcp-go](https://github.com/mark3labs/mcp-go) - Go SDK for MCP servers
+- [go-sdk](https://github.com/modelcontextprotocol/go-sdk) - Official Go SDK for MCP
 - [OpenShift Lightspeed](https://docs.openshift.com/container-platform/latest/lightspeed/index.html) - AI-powered OpenShift assistant
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/google/go-containerregistry v0.20.7
-	github.com/mark3labs/mcp-go v0.43.2
+	github.com/modelcontextprotocol/go-sdk v1.2.0
 	github.com/onsi/ginkgo/v2 v2.27.5
 	github.com/onsi/gomega v1.39.0
 	github.com/openshift/kube-compare v0.12.0
@@ -23,9 +23,7 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
-	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -46,6 +44,7 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gosimple/slug v1.15.0 // indirect
@@ -53,7 +52,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -82,7 +80,6 @@ require (
 	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/vbatts/tar-split v0.12.2 // indirect
-	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
-github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
-github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/chai2010/gettext-go v1.0.2 h1:1Lwwip6Q2QGsAdl/ZKPCwTe9fe0CjlUbqj5bFNSjIRk=
 github.com/chai2010/gettext-go v1.0.2/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/containerd/stargz-snapshotter/estargz v0.18.1 h1:cy2/lpgBXDA3cDKSyEfNOFMA/c10O1axL69EU7iirO8=
@@ -70,6 +66,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
@@ -79,6 +77,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/go-containerregistry v0.20.7 h1:24VGNpS0IwrOZ2ms2P1QE3Xa5X9p4phx0aUgzYzHW6I=
 github.com/google/go-containerregistry v0.20.7/go.mod h1:Lx5LCZQjLH1QBaMPeGwsME9biPeo1lPx6lbGj/UmzgM=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -93,8 +93,6 @@ github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
-github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -119,8 +117,6 @@ github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffkt
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy/I=
-github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/maruel/natural v1.1.1 h1:Hja7XhhmvEFhcByqDoHz9QZbkWey+COd9xWfCfn1ioo=
 github.com/maruel/natural v1.1.1/go.mod h1:v+Rfd79xlw1AgVBjbO0BEQmptqb5HvL/k9GRHB7ZKEg=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
@@ -135,6 +131,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.2.0 h1:Y23co09300CEk8iZ/tMxIX1dVmKZkzoSBZOpJwUnc/s=
+github.com/modelcontextprotocol/go-sdk v1.2.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -204,8 +202,6 @@ github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
-github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
-github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/pkg/mcpserver/compare_test.go
+++ b/pkg/mcpserver/compare_test.go
@@ -417,10 +417,6 @@ var _ = Describe("CompareHandler", func() {
 		It("has description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
 		})
-
-		It("requires reference parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("reference"))
-		})
 	})
 })
 

--- a/pkg/mcpserver/rds_compare_test.go
+++ b/pkg/mcpserver/rds_compare_test.go
@@ -180,24 +180,6 @@ var _ = Describe("RDSCompareHandler", func() {
 		It("has a description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
 		})
-
-		It("requires rds_type parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("rds_type"))
-		})
-
-		It("does not require kubeconfig (in-cluster mode supported)", func() {
-			Expect(tool.InputSchema.Required).NotTo(ContainElement("kubeconfig"))
-		})
-
-		It("has output_format parameter", func() {
-			props := tool.InputSchema.Properties
-			Expect(props).To(HaveKey("output_format"))
-		})
-
-		It("has all_resources parameter", func() {
-			props := tool.InputSchema.Properties
-			Expect(props).To(HaveKey("all_resources"))
-		})
 	})
 
 	Describe("RDSCompareArgs struct", func() {

--- a/pkg/mcpserver/rds_test.go
+++ b/pkg/mcpserver/rds_test.go
@@ -267,14 +267,6 @@ var _ = Describe("ReferenceHandler", func() {
 		It("has a description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
 		})
-
-		It("requires rds_type parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("rds_type"))
-		})
-
-		It("does not require kubeconfig (in-cluster mode supported)", func() {
-			Expect(tool.InputSchema.Required).NotTo(ContainElement("kubeconfig"))
-		})
 	})
 
 	Describe("GetRDSConfigs", func() {

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -5,7 +5,7 @@ package mcpserver
 import (
 	"log/slog"
 
-	"github.com/mark3labs/mcp-go/server"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ServerName is the name of the MCP server.
@@ -13,7 +13,7 @@ const ServerName = "kube-compare-mcp"
 
 // NewServer creates a new MCP server with the cluster-compare tool registered.
 // The version parameter should be passed from the build-time version in main.go.
-func NewServer(version string) *server.MCPServer {
+func NewServer(version string) *mcp.Server {
 	logger := slog.Default()
 
 	logger.Debug("Creating MCP server",
@@ -21,15 +21,17 @@ func NewServer(version string) *server.MCPServer {
 		"version", version,
 	)
 
-	s := server.NewMCPServer(
-		ServerName,
-		version,
-		server.WithToolCapabilities(true),
+	s := mcp.NewServer(
+		&mcp.Implementation{
+			Name:    ServerName,
+			Version: version,
+		},
+		nil,
 	)
 
-	s.AddTool(ClusterCompareTool(), HandleClusterCompare)
-	s.AddTool(FindRDSReferenceTool(), HandleFindRDSReference)
-	s.AddTool(CompareClusterRDSTool(), HandleCompareClusterRDS)
+	mcp.AddTool(s, ClusterCompareTool(), HandleClusterCompare)
+	mcp.AddTool(s, FindRDSReferenceTool(), HandleFindRDSReference)
+	mcp.AddTool(s, CompareClusterRDSTool(), HandleCompareClusterRDS)
 
 	logger.Info("MCP server initialized",
 		"name", ServerName,

--- a/pkg/mcpserver/server_test.go
+++ b/pkg/mcpserver/server_test.go
@@ -33,18 +33,6 @@ var _ = Describe("Server", func() {
 		It("has a description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
 		})
-
-		It("has input schema with properties", func() {
-			Expect(tool.InputSchema.Properties).NotTo(BeNil())
-		})
-
-		It("requires the reference parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("reference"))
-		})
-
-		It("does not require kubeconfig (in-cluster mode supported)", func() {
-			Expect(tool.InputSchema.Required).NotTo(ContainElement("kubeconfig"))
-		})
 	})
 
 	Describe("FindRDSReferenceTool", func() {
@@ -57,14 +45,6 @@ var _ = Describe("Server", func() {
 		It("has a description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
 		})
-
-		It("requires the rds_type parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("rds_type"))
-		})
-
-		It("does not require kubeconfig (in-cluster mode supported)", func() {
-			Expect(tool.InputSchema.Required).NotTo(ContainElement("kubeconfig"))
-		})
 	})
 
 	Describe("CompareClusterRDSTool", func() {
@@ -76,14 +56,6 @@ var _ = Describe("Server", func() {
 
 		It("has a description", func() {
 			Expect(tool.Description).NotTo(BeEmpty())
-		})
-
-		It("requires the rds_type parameter", func() {
-			Expect(tool.InputSchema.Required).To(ContainElement("rds_type"))
-		})
-
-		It("does not require kubeconfig (in-cluster mode supported)", func() {
-			Expect(tool.InputSchema.Required).NotTo(ContainElement("kubeconfig"))
 		})
 	})
 

--- a/pkg/mcpserver/test_fixtures_test.go
+++ b/pkg/mcpserver/test_fixtures_test.go
@@ -4,11 +4,12 @@ package mcpserver_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // Kubeconfig fixtures for testing
@@ -134,20 +135,28 @@ func EncodeKubeconfig(kc string) string {
 }
 
 // NewMCPRequest creates an MCP CallToolRequest with the given arguments.
-func NewMCPRequest(args map[string]interface{}) mcp.CallToolRequest {
-	return mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
-			Arguments: args,
+func NewMCPRequest(args map[string]interface{}) *mcp.CallToolRequest {
+	var rawArgs json.RawMessage
+	if args != nil {
+		rawArgs, _ = json.Marshal(args)
+	}
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
+			Arguments: rawArgs,
 		},
 	}
 }
 
 // NewMCPRequestWithName creates an MCP CallToolRequest with tool name and arguments.
-func NewMCPRequestWithName(name string, args map[string]interface{}) mcp.CallToolRequest {
-	return mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
+func NewMCPRequestWithName(name string, args map[string]interface{}) *mcp.CallToolRequest {
+	var rawArgs json.RawMessage
+	if args != nil {
+		rawArgs, _ = json.Marshal(args)
+	}
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{
 			Name:      name,
-			Arguments: args,
+			Arguments: rawArgs,
 		},
 	}
 }


### PR DESCRIPTION
Replace third-party mark3labs/mcp-go with official SDK for better spec compliance and typed tool inputs with jsonschema validation.