### PR TITLE
Remove SSE transport (deprecated in MCP spec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flowchart TB
     end
 
     subgraph server [kube-compare-mcp Server]
-        Transport[Transport Layer<br/>stdio / sse / http]
+        Transport[Transport Layer<br/>stdio / http]
         Tools[MCP Tools]
         ClusterCompare[cluster_compare]
         FindRDS[find_rds_reference]
@@ -85,8 +85,8 @@ make build
 # Run locally with stdio transport (for local MCP clients)
 ./bin/kube-compare-mcp
 
-# Or run with SSE transport for network access
-./bin/kube-compare-mcp --transport=sse --port=8080
+# Or run with HTTP transport for network access
+./bin/kube-compare-mcp --transport=http --port=8080
 ```
 
 ## Installation
@@ -129,8 +129,8 @@ make build-all
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--transport` | Transport mode: `stdio`, `sse`, or `http` | `stdio` |
-| `--port` | Port to listen on (for `sse` and `http` transports) | `8080` |
+| `--transport` | Transport mode: `stdio` or `http` | `stdio` |
+| `--port` | Port to listen on (for `http` transport) | `8080` |
 | `--log-level` | Log level: `debug`, `info`, `warn`, `error` | `info` |
 | `--log-format` | Log format: `text`, `json` | `text` |
 | `--version` | Show version information | - |
@@ -145,22 +145,9 @@ For local MCP clients like Cursor and Claude Desktop running on the same machine
 ./bin/kube-compare-mcp --transport=stdio
 ```
 
-#### SSE (Server-Sent Events)
-
-For network access, exposing endpoints at `/sse` and `/message`:
-
-```bash
-./bin/kube-compare-mcp --transport=sse --port=8080
-```
-
-Endpoints:
-- `GET /sse` - SSE connection endpoint
-- `POST /message` - Message endpoint
-- `GET /health` - Health check endpoint
-
 #### HTTP (Streamable HTTP)
 
-For OpenShift Lightspeed (OLS) integration:
+For network access and MCP client integration (Cursor, Claude Desktop, OpenShift Lightspeed):
 
 ```bash
 ./bin/kube-compare-mcp --transport=http --port=8080
@@ -238,7 +225,7 @@ spec:
       streamableHTTP:
         url: http://kube-compare-mcp.kube-compare-mcp.svc.cluster.local:8080/mcp
         timeout: 60
-        sseReadTimeout: 30
+        sseReadTimeout: 0
         enableSSE: false
 ```
 
@@ -252,7 +239,7 @@ Configure your MCP client to connect to the server's endpoint:
 {
   "mcpServers": {
     "kube-compare": {
-      "url": "https://kube-compare-mcp-route.apps.your-cluster.example.com/sse"
+      "url": "https://kube-compare-mcp-route.apps.your-cluster.example.com/mcp"
     }
   }
 }
@@ -264,7 +251,7 @@ Configure your MCP client to connect to the server's endpoint:
 {
   "mcpServers": {
     "kube-compare": {
-      "url": "https://kube-compare-mcp-route.apps.your-cluster.example.com/sse"
+      "url": "https://kube-compare-mcp-route.apps.your-cluster.example.com/mcp"
     }
   }
 }
@@ -599,7 +586,7 @@ export KUBE_COMPARE_MCP_IMAGE_PULL_TIMEOUT=10m
 # Increase validation timeouts for slow networks
 export KUBE_COMPARE_MCP_HTTP_VALIDATION_TIMEOUT=30s
 export KUBE_COMPARE_MCP_OCI_VALIDATION_TIMEOUT=60s
-./bin/kube-compare-mcp --transport=sse --port=8080
+./bin/kube-compare-mcp --transport=http --port=8080
 ```
 
 ## Development

--- a/cmd/kube-compare-mcp/main.go
+++ b/cmd/kube-compare-mcp/main.go
@@ -24,8 +24,8 @@ var version = "dev"
 
 func main() {
 	// Parse command-line flags
-	transport := flag.String("transport", "stdio", "Transport mode: stdio, sse, or http")
-	port := flag.Int("port", 8080, "Port to listen on (for sse and http transports)")
+	transport := flag.String("transport", "stdio", "Transport mode: stdio or http")
+	port := flag.Int("port", 8080, "Port to listen on (for http transport)")
 	logLevel := flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	logFormat := flag.String("log-format", "text", "Log format: text, json")
 	showVersion := flag.Bool("version", false, "Show version information")
@@ -52,8 +52,6 @@ func main() {
 	switch *transport {
 	case "stdio":
 		runStdioServer(s, logger)
-	case "sse":
-		runSSEServer(s, *port, logger)
 	case "http":
 		runHTTPServer(s, *port, logger)
 	default:
@@ -101,63 +99,6 @@ func runStdioServer(s *mcp.Server, logger *slog.Logger) {
 		logger.Error("Server error", "error", err)
 		os.Exit(1)
 	}
-}
-
-// runSSEServer starts the server using SSE (Server-Sent Events) transport
-func runSSEServer(s *mcp.Server, port int, logger *slog.Logger) {
-	addr := fmt.Sprintf(":%d", port)
-	logger.Info("Starting SSE server",
-		"addr", addr,
-		"sseEndpoint", fmt.Sprintf("http://localhost:%d/sse", port),
-		"messageEndpoint", fmt.Sprintf("http://localhost:%d/message", port),
-		"healthEndpoint", fmt.Sprintf("http://localhost:%d/health", port),
-	)
-
-	// Create a mux to handle both SSE and health endpoints
-	mux := http.NewServeMux()
-
-	// Health endpoint for Kubernetes liveness/readiness probes
-	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	})
-
-	// SSE endpoints handled by the MCP SSE handler
-	sseHandler := mcp.NewSSEHandler(func(*http.Request) *mcp.Server { return s }, nil)
-	mux.Handle("/sse", sseHandler)
-	mux.Handle("/message", sseHandler)
-
-	// Wrap with logging middleware
-	handler := loggingMiddleware(mux, logger)
-
-	httpServer := &http.Server{
-		Addr:              addr,
-		Handler:           handler,
-		ReadHeaderTimeout: 30 * time.Second,
-		ReadTimeout:       60 * time.Second,
-		WriteTimeout:      120 * time.Second, // Longer timeout for SSE streaming
-		IdleTimeout:       120 * time.Second,
-	}
-
-	// Handle graceful shutdown
-	go func() {
-		sigChan := make(chan os.Signal, 1)
-		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-		sig := <-sigChan
-
-		logger.Info("Received shutdown signal", "signal", sig)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := httpServer.Shutdown(ctx); err != nil {
-			logger.Error("Error during shutdown", "error", err)
-		}
-	}()
-
-	if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-		logger.Error("SSE server error", "error", err)
-		os.Exit(1)
-	}
-	logger.Info("Server stopped")
 }
 
 // runHTTPServer starts the server using Streamable HTTP transport
@@ -240,7 +181,7 @@ func loggingMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 }
 
 // responseWriter wraps http.ResponseWriter to capture the status code.
-// It implements http.Flusher to support SSE streaming.
+// It implements http.Flusher to support HTTP streaming.
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
@@ -251,7 +192,7 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-// Flush implements http.Flusher interface for SSE support.
+// Flush implements http.Flusher interface for HTTP streaming support.
 func (rw *responseWriter) Flush() {
 	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
 		flusher.Flush()

--- a/pkg/mcpserver/compare.go
+++ b/pkg/mcpserver/compare.go
@@ -115,7 +115,7 @@ func getImagePullTimeout() time.Duration {
 var requestIDCounter atomic.Uint64
 
 // generateRequestID creates a unique request ID for correlation logging.
-// Thread-safe for concurrent use across HTTP/SSE handlers.
+// Thread-safe for concurrent use across HTTP handlers.
 func generateRequestID() string {
 	counter := requestIDCounter.Add(1)
 	return fmt.Sprintf("%d-%05d", time.Now().Unix(), counter%100000)


### PR DESCRIPTION
Remove SSE transport in favor of Streamable HTTP per the [MCP spec deprecation (March 2025)](https://modelcontextprotocol.io/specification/2025-03-26/changelog). Use --transport=http for network access.

BREAKING CHANGE: --transport=sse no longer supported