### PR TITLE
Fix MCP spec violation: log to stderr instead of stdout

### DIFF
--- a/cmd/kube-compare-mcp/main.go
+++ b/cmd/kube-compare-mcp/main.go
@@ -84,9 +84,9 @@ func initLogger(level, format string) *slog.Logger {
 	var handler slog.Handler
 	switch strings.ToLower(format) {
 	case "json":
-		handler = slog.NewJSONHandler(os.Stdout, opts)
+		handler = slog.NewJSONHandler(os.Stderr, opts)
 	default:
-		handler = slog.NewTextHandler(os.Stdout, opts)
+		handler = slog.NewTextHandler(os.Stderr, opts)
 	}
 
 	return slog.New(handler)


### PR DESCRIPTION
For stdio transport, stdout is reserved for MCP JSON-RPC protocol messages. Logging to stdout corrupts the protocol communication.

Per MCP specification, server logs must go to stderr.

Fixes #16