### PR TITLE
Add MCP tool annotations to help clients understand tool behaviour

### DIFF
--- a/pkg/mcpserver/compare.go
+++ b/pkg/mcpserver/compare.go
@@ -72,6 +72,11 @@ type ClusterCompareInput struct {
 // ClusterCompareOutput is an empty output struct (tool returns text content).
 type ClusterCompareOutput struct{}
 
+// ptrBool returns a pointer to a bool value, used for optional annotation fields.
+func ptrBool(b bool) *bool {
+	return &b
+}
+
 // ClusterCompareTool returns the MCP tool definition for cluster-compare.
 func ClusterCompareTool() *mcp.Tool {
 	return &mcp.Tool{
@@ -79,6 +84,12 @@ func ClusterCompareTool() *mcp.Tool {
 		Description: "Compare Kubernetes cluster configurations against a reference configuration. " +
 			"Detects configuration drift between live cluster resources and a known-good reference template. " +
 			"References must be provided as HTTP/HTTPS URLs or OCI container image references.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    true,
+			DestructiveHint: ptrBool(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   ptrBool(true),
+		},
 	}
 }
 

--- a/pkg/mcpserver/rds.go
+++ b/pkg/mcpserver/rds.go
@@ -94,6 +94,12 @@ func FindRDSReferenceTool() *mcp.Tool {
 			"Can query a cluster via kubeconfig to auto-detect the OpenShift version, accept an explicit version, " +
 			"or use in-cluster config when running inside an OpenShift cluster (no parameters needed). " +
 			"The tool automatically selects the best available RHEL variant from the registry (preferring newer versions).",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    true,
+			DestructiveHint: ptrBool(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   ptrBool(true),
+		},
 	}
 }
 

--- a/pkg/mcpserver/rds_compare.go
+++ b/pkg/mcpserver/rds_compare.go
@@ -41,6 +41,12 @@ func CompareClusterRDSTool() *mcp.Tool {
 			"This tool automatically detects the cluster version, finds the appropriate RDS container reference, and " +
 			"performs the comparison. When running inside an OpenShift cluster, no kubeconfig is needed - it will use " +
 			"in-cluster config to compare the local cluster. Combines find_rds_reference and cluster_compare into a single operation.",
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:    true,
+			DestructiveHint: ptrBool(false),
+			IdempotentHint:  true,
+			OpenWorldHint:   ptrBool(true),
+		},
 	}
 }
 


### PR DESCRIPTION
All three tools now include ToolAnnotations with:
- ReadOnlyHint: true (tools only read cluster state)
- DestructiveHint: false (no destructive operations)
- IdempotentHint: true (same inputs produce same outputs)
- OpenWorldHint: true (interacts with external systems)

These hints help MCP clients make informed decisions about tool invocation, permissions, and caching.

Closes #17