### PR TITLE
Add Telco Hub RDS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Get the correct Red Hat Telco RDS container reference for a cluster's OpenShift 
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `rds_type` | string | Yes | RDS type: `core` for Telco Core RDS or `ran` for Telco RAN DU RDS. |
+| `rds_type` | string | Yes | RDS type: `core` for Telco Core RDS, `ran` for Telco RAN DU RDS, or `hub` for Telco Hub RDS (requires OCP 4.19+). |
 | `ocp_version` | string | No | Explicit OpenShift version (e.g., `4.18`, `4.20.0`). If not provided, auto-detects from cluster. |
 | `kubeconfig` | string | No | Kubeconfig content (raw YAML or base64-encoded, auto-detected). If not provided and `ocp_version` is not set, uses in-cluster config. |
 | `context` | string | No | Kubernetes context name to use from the provided kubeconfig. |
@@ -336,13 +336,17 @@ Find the Telco Core RDS reference for my OpenShift 4.18 cluster
 What RDS reference should I use for a RAN deployment on OpenShift 4.20?
 ```
 
+```
+Find the Telco Hub RDS reference for my OpenShift 4.19 cluster
+```
+
 ### kube_compare_validate_rds
 
 Validate an OpenShift cluster's compliance with Red Hat Telco RDS. This is the recommended tool for RDS validation.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `rds_type` | string | Yes | RDS type: `core` for Telco Core RDS or `ran` for Telco RAN DU RDS. |
+| `rds_type` | string | Yes | RDS type: `core` for Telco Core RDS, `ran` for Telco RAN DU RDS, or `hub` for Telco Hub RDS (requires OCP 4.19+). |
 | `output_format` | string | No | Output format: `json`, `yaml`, or `junit`. Default: `json`. |
 | `all_resources` | boolean | No | Compare all resources of types mentioned in the reference. Default: `false`. |
 | `kubeconfig` | string | No | Kubeconfig content (raw YAML or base64-encoded, auto-detected). If not provided, uses in-cluster config. |
@@ -375,6 +379,10 @@ Compare my cluster against the Telco Core RDS
 
 ```
 Check if my OpenShift cluster is compliant with the Telco RAN DU reference design
+```
+
+```
+Validate my hub cluster against the Telco Hub RDS for OpenShift 4.19
 ```
 
 ### baremetal_bios_diff
@@ -462,6 +470,14 @@ For Radio Access Network Distributed Unit workloads.
 
 - **Image**: `registry.redhat.io/openshift4/ztp-site-generate-rhel8`
 - **RHEL Variants**: rhel8 only
+
+### Telco Hub RDS (`hub`)
+
+For Advanced Cluster Management hub clusters.
+
+- **Image**: `registry.redhat.io/openshift4/openshift-telco-hub-rds-rhel9`
+- **RHEL Variants**: rhel9 (preferred), rhel8
+- **Minimum OpenShift Version**: 4.19
 
 ### Automatic Version Detection
 

--- a/pkg/mcpserver/rds.go
+++ b/pkg/mcpserver/rds.go
@@ -26,14 +26,16 @@ var (
 const (
 	RDSTypeCore     = "core"
 	RDSTypeRAN      = "ran"
+	RDSTypeHub      = "hub"
 	registryTimeout = 30 * time.Second
 )
 
 // RDSConfig holds the configuration for an RDS reference type.
 type RDSConfig struct {
-	ImageBase    string   // e.g., "registry.redhat.io/openshift4/openshift-telco-core-rds"
-	Path         string   // Path to metadata.yaml within the container
-	RHELVariants []string // RHEL variants to try in order of preference (e.g., ["rhel9", "rhel8"])
+	ImageBase     string   // e.g., "registry.redhat.io/openshift4/openshift-telco-core-rds"
+	Path          string   // Path to metadata.yaml within the container
+	RHELVariants  []string // RHEL variants to try in order of preference (e.g., ["rhel9", "rhel8"])
+	MinOCPVersion string   // Minimum OpenShift version required (e.g., "v4.19"); empty means no minimum
 }
 
 var rdsConfigs = map[string]RDSConfig{
@@ -47,6 +49,20 @@ var rdsConfigs = map[string]RDSConfig{
 		Path:         "/home/ztp/reference/metadata.yaml",
 		RHELVariants: []string{"rhel8"},
 	},
+	RDSTypeHub: {
+		ImageBase:     "registry.redhat.io/openshift4/openshift-telco-hub-rds",
+		Path:          "/telco-hub/configuration/reference-crs-kube-compare/metadata.yaml",
+		RHELVariants:  []string{"rhel9", "rhel8"},
+		MinOCPVersion: "v4.19",
+	},
+}
+
+func init() {
+	for name, cfg := range rdsConfigs {
+		if cfg.MinOCPVersion != "" && !versionTagRegex.MatchString(cfg.MinOCPVersion) {
+			panic(fmt.Sprintf("rdsConfigs[%q].MinOCPVersion %q does not match vMAJOR.MINOR format", name, cfg.MinOCPVersion))
+		}
+	}
 }
 
 // ResolveRDSResult is the structured response for the kube_compare_resolve_rds tool.
@@ -80,7 +96,7 @@ var defaultReferenceService = NewReferenceService()
 type ResolveRDSInput struct {
 	Kubeconfig string `json:"kubeconfig,omitempty" jsonschema:"Kubeconfig content (raw YAML or base64-encoded) for connecting to the target cluster. If omitted, uses in-cluster config."`
 	Context    string `json:"context,omitempty" jsonschema:"Kubernetes context name to use from the provided kubeconfig"`
-	RDSType    string `json:"rds_type" jsonschema:"RDS type to find: core for Telco Core RDS or ran for Telco RAN DU RDS"`
+	RDSType    string `json:"rds_type" jsonschema:"RDS type to find: core for Telco Core RDS, ran for Telco RAN DU RDS, or hub for Telco Hub RDS"`
 	OCPVersion string `json:"ocp_version,omitempty" jsonschema:"OpenShift version (e.g. 4.18 or 4.20.0)"`
 }
 
@@ -241,6 +257,15 @@ func (s *ReferenceService) ResolveRDS(ctx context.Context, args *ResolveRDSArgs)
 
 	ocpVersion := ExtractMajorMinorVersion(clusterVersion)
 	cfg := rdsConfigs[args.RDSType]
+
+	if cfg.MinOCPVersion != "" && CompareVersionTags(ocpVersion, cfg.MinOCPVersion) < 0 {
+		return nil, NewValidationError(
+			"ocp_version",
+			fmt.Sprintf("%s RDS requires OpenShift %s or later, but cluster is running %s",
+				args.RDSType, cfg.MinOCPVersion, ocpVersion),
+			fmt.Sprintf("use 'core' or 'ran' RDS types for OpenShift versions earlier than %s", cfg.MinOCPVersion),
+		)
+	}
 
 	rhelVariant, repoRef, versionTags, err := s.findBestRHELVariant(ctx, cfg, ocpVersion)
 	if err != nil {

--- a/pkg/mcpserver/rds_compare.go
+++ b/pkg/mcpserver/rds_compare.go
@@ -24,7 +24,7 @@ type ValidateRDSResult struct {
 type ValidateRDSInput struct {
 	Kubeconfig   string `json:"kubeconfig,omitempty" jsonschema:"Kubeconfig content (raw YAML or base64-encoded) for connecting to the target cluster. If omitted, uses in-cluster config."`
 	Context      string `json:"context,omitempty" jsonschema:"Kubernetes context name to use from the provided kubeconfig"`
-	RDSType      string `json:"rds_type" jsonschema:"RDS type to compare against: core for Telco Core RDS or ran for Telco RAN DU RDS"`
+	RDSType      string `json:"rds_type" jsonschema:"RDS type to compare against: core for Telco Core RDS, ran for Telco RAN DU RDS, or hub for Telco Hub RDS"`
 	OutputFormat string `json:"output_format,omitempty" jsonschema:"Output format for the comparison results"`
 	AllResources bool   `json:"all_resources,omitempty" jsonschema:"Compare all resources of types mentioned in the reference"`
 }

--- a/pkg/mcpserver/rds_test.go
+++ b/pkg/mcpserver/rds_test.go
@@ -47,6 +47,12 @@ var _ = Describe("ReferenceHandler", func() {
 			Entry("RAN RDS with RHEL8",
 				mcpserver.RDSTypeRAN, "rhel8", "v4.17",
 				"ztp-site-generate-rhel8:v4.17"),
+			Entry("hub RDS with RHEL9",
+				mcpserver.RDSTypeHub, "rhel9", "v4.19",
+				"openshift-telco-hub-rds-rhel9:v4.19"),
+			Entry("hub RDS with RHEL8",
+				mcpserver.RDSTypeHub, "rhel8", "v4.20",
+				"openshift-telco-hub-rds-rhel8:v4.20"),
 		)
 	})
 
@@ -116,6 +122,10 @@ var _ = Describe("ReferenceHandler", func() {
 
 		It("has RAN RDS config", func() {
 			Expect(mcpserver.RDSTypeRAN).To(Equal("ran"))
+		})
+
+		It("has Hub RDS config", func() {
+			Expect(mcpserver.RDSTypeHub).To(Equal("hub"))
 		})
 	})
 
@@ -253,6 +263,46 @@ var _ = Describe("ReferenceHandler", func() {
 				_, err := service.ResolveRDS(context.Background(), args)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("accessible"))
+			})
+		})
+
+		Context("when hub RDS is requested with OCP version below minimum (4.19)", func() {
+			It("returns a validation error without hitting the registry", func() {
+				// No registry mock expectations — the min version check must fire before any registry call
+				args := &mcpserver.ResolveRDSArgs{
+					RDSType:    mcpserver.RDSTypeHub,
+					OCPVersion: "4.18.0",
+				}
+
+				_, err := service.ResolveRDS(context.Background(), args)
+				Expect(err).To(HaveOccurred())
+
+				var valErr *mcpserver.ValidationError
+				Expect(errors.As(err, &valErr)).To(BeTrue(), "expected a ValidationError")
+				Expect(valErr.Error()).To(ContainSubstring("hub"))
+				Expect(valErr.Error()).To(ContainSubstring("v4.19"))
+			})
+		})
+
+		Context("when hub RDS is requested with OCP version at the minimum (4.19)", func() {
+			It("passes the version check and resolves the reference", func() {
+				mockRegistry.EXPECT().
+					ListTags(gomock.Any(), gomock.Any()).
+					Return([]string{"v4.19", "v4.20"}, nil).
+					AnyTimes()
+				mockRegistry.EXPECT().
+					HeadImage(gomock.Any(), gomock.Any()).
+					Return(nil).
+					AnyTimes()
+
+				args := &mcpserver.ResolveRDSArgs{
+					RDSType:    mcpserver.RDSTypeHub,
+					OCPVersion: "4.19.0",
+				}
+
+				result, err := service.ResolveRDS(context.Background(), args)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Reference).To(ContainSubstring("telco-hub-rds"))
 			})
 		})
 	})

--- a/pkg/mcpserver/schema.go
+++ b/pkg/mcpserver/schema.go
@@ -40,7 +40,7 @@ func ResolveRDSInputSchema() *jsonschema.Schema {
 
 	// Add enum constraint for rds_type
 	if prop, ok := schema.Properties["rds_type"]; ok {
-		prop.Enum = []any{"core", "ran"}
+		prop.Enum = []any{"core", "ran", "hub"}
 	}
 
 	makeOptionalFieldsNullable(schema)
@@ -57,7 +57,7 @@ func ValidateRDSInputSchema() *jsonschema.Schema {
 
 	// Add enum constraint for rds_type
 	if prop, ok := schema.Properties["rds_type"]; ok {
-		prop.Enum = []any{"core", "ran"}
+		prop.Enum = []any{"core", "ran", "hub"}
 	}
 
 	// Add enum constraint for output_format

--- a/pkg/mcpserver/schema_test.go
+++ b/pkg/mcpserver/schema_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Schema", func() {
 		It("has rds_type property with enum constraint", func() {
 			prop, ok := schema.Properties["rds_type"]
 			Expect(ok).To(BeTrue(), "rds_type property should exist")
-			Expect(prop.Enum).To(ConsistOf("core", "ran"))
+			Expect(prop.Enum).To(ConsistOf("core", "ran", "hub"))
 		})
 
 		It("has kubeconfig property", func() {
@@ -76,7 +76,7 @@ var _ = Describe("Schema", func() {
 		It("has rds_type property with enum constraint", func() {
 			prop, ok := schema.Properties["rds_type"]
 			Expect(ok).To(BeTrue(), "rds_type property should exist")
-			Expect(prop.Enum).To(ConsistOf("core", "ran"))
+			Expect(prop.Enum).To(ConsistOf("core", "ran", "hub"))
 		})
 
 		It("has output_format property with enum constraint", func() {


### PR DESCRIPTION
@sakhoury, I added Telco Hub RDS type for ACM hub cluster validation, as I'm working with a partner on OCP Hub RDS alignment.

Changes:
- New RDS type: hub
- Registry: registry.redhat.io/openshift4/openshift-telco-hub-rds
- RHEL variants: rhel9, rhel8
- Min OCP: 4.19

All 210/210 test specifications passed.