### PR TITLE
rds-version-diff: new mcp tool that allow listing diffs between RDS versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,10 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
     -o build/kube-compare-mcp \
     ./cmd/kube-compare-mcp
 
-#####################################################################################################
-# Build the runtime image 
+# PolicyGenerator binary from ACM image. Build must have access to registry.redhat.io (e.g. podman login).
+FROM registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9:v2.16 AS policygen-extract
+
+# Build the runtime image
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV SUMMARY="MCP server for Kubernetes / OpenShift cluster compliance" \
@@ -40,13 +42,19 @@ LABEL name="kube-compare-mcp" \
       io.k8s.description="${DESCRIPTION}" \
       io.openshift.tags="kubernetes,mcp,kube-compare,ai"
 
-# Install diff utility which is required by kube-compare
-RUN microdnf install -y diffutils --nodocs && \
+# Install diff utility which is required by kube-compare.
+# Use only UBI repos (disable rhel-* repos that require subscription and return 403).
+RUN microdnf install -y --disablerepo='rhel-*' diffutils --nodocs && \
     microdnf clean all
 
 COPY --from=builder \
     /opt/app-root/src/build/kube-compare-mcp \
     /usr/local/bin/
+
+# PolicyGenerator binary for RDS version diff (from ACM image)
+COPY --from=policygen-extract /policy-generator/PolicyGenerator-rhel8 /usr/local/bin/PolicyGenerator-rhel8
+RUN chmod 755 /usr/local/bin/PolicyGenerator-rhel8
+ENV POLICY_GENERATOR_BINARY_PATH=/usr/local/bin/PolicyGenerator-rhel8
 
 # Copy the license
 COPY LICENSE /licenses/LICENSE

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ MCP server for [kube-compare](https://github.com/openshift/kube-compare) - enabl
   - [kube_compare_resolve_rds](#kube_compare_resolve_rds)
   - [kube_compare_validate_rds](#kube_compare_validate_rds)
   - [baremetal_bios_diff](#baremetal_bios_diff)
+  - [kube_compare_rds_version_diff](#kube_compare_rds_version_diff)
 - [RDS Support](#rds-reference-design-specification-support)
 - [BIOS Reference Configurations](#bios-reference-configurations)
 - [Connecting to Remote Clusters](#connecting-to-remote-clusters)
@@ -54,6 +55,7 @@ flowchart TB
         ResolveRDS[kube_compare_resolve_rds]
         ValidateRDS[kube_compare_validate_rds]
         BIOSDiff[baremetal_bios_diff]
+        RDSVersionDiff[kube_compare_rds_version_diff]
     end
 
     subgraph external [External Resources]
@@ -70,6 +72,7 @@ flowchart TB
     Tools --> ResolveRDS
     Tools --> ValidateRDS
     Tools --> BIOSDiff
+    Tools --> RDSVersionDiff
     Diff --> K8sCluster
     Diff --> Registry
     Diff --> HTTPRef
@@ -278,7 +281,7 @@ Configure your MCP client to connect to the server's endpoint:
 
 ## MCP Tools Reference
 
-The server exposes four MCP tools:
+The server exposes five MCP tools:
 
 ### kube_compare_cluster_diff
 
@@ -443,6 +446,28 @@ Check if host worker-0 in namespace my-cluster has compliant BIOS settings
 
 ```
 Validate BIOS configuration for all bare metal hosts in the spoke-cluster-1 namespace
+```
+
+### kube_compare_rds_version_diff
+
+Compare RDS (telco reference) configuration between two versions. Accepts two full GitHub tree URLs (old and new), downloads the telco-reference sources, runs the PolicyGenerator binary (path from `POLICY_GENERATOR_BINARY_PATH` env, set in the container image) to generate policies, then extracts CRs and reports differences. All artifacts are stored under a session directory whose path is returned in the result.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `old_version_url` | string | Yes | Full GitHub tree URL for the older version, e.g. `https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-18/telco-ran/configuration`. |
+| `new_version_url` | string | Yes | Full GitHub tree URL for the newer version, e.g. `https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration`. |
+| `work_dir` | string | No | Base directory for session artifacts. Default: `RDS_DIFF_WORK_DIR` env or OS temp dir. |
+
+**Response:** Summary text, diff report snippet, and **Artifacts path:** pointing to the session directory (containing `old/`, `new/`, `diff-report.txt`, `comparison.json`, etc.).
+
+**Example prompts:**
+
+```
+Compare RDS configuration between telco-reference 4.18 and 4.20 using GitHub URLs
+```
+
+```
+Run RDS version diff for https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-18/telco-ran/configuration and https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration
 ```
 
 ## RDS (Reference Design Specification) Support
@@ -732,6 +757,7 @@ The server behavior can be customized using environment variables:
 | `KUBE_COMPARE_MCP_IMAGE_PULL_TIMEOUT` | Timeout for pulling container images (Go duration string) | `5m` |
 | `KUBE_COMPARE_MCP_HTTP_VALIDATION_TIMEOUT` | Timeout for validating HTTP/HTTPS reference URLs (Go duration string) | `10s` |
 | `KUBE_COMPARE_MCP_OCI_VALIDATION_TIMEOUT` | Timeout for validating OCI container image references (Go duration string) | `30s` |
+| `RDS_DIFF_WORK_DIR` | Base directory for RDS version diff session artifacts (downloads, generated policies, reports). If unset, uses OS temp dir. | (OS temp) |
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ kubectl apply -k deploy/
 
 This creates:
 - A Deployment running the MCP server with HTTP transport
+- A PersistentVolumeClaim (`rds-diff-artifacts`, 5Gi) for RDS version diff session artifacts, mounted at `/var/rds-diff-artifacts` so sessions persist across pod restarts and are served at `GET /artifacts/<artifact_id>/...`
 - A Service exposing the MCP server
 - A Route (OpenShift) for external access
 - RBAC resources for cluster read access
@@ -458,7 +459,14 @@ Compare RDS (telco reference) configuration between two versions. Accepts two fu
 | `new_version_url` | string | Yes | Full GitHub tree URL for the newer version, e.g. `https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration`. |
 | `work_dir` | string | No | Base directory for session artifacts. Default: `RDS_DIFF_WORK_DIR` env or OS temp dir. |
 
-**Response:** Summary text, diff report snippet, and **Artifacts path:** pointing to the session directory (containing `old/`, `new/`, `diff-report.txt`, `comparison.json`, etc.).
+**Response:** Summary text, diff report snippet, **artifact_id** (session directory name), **Artifacts path** (server-local path), and when running over HTTP you can download all generated files at `GET <mcp-base-url>/artifacts/<artifact_id>/...`. Key paths under the session:
+
+- `diff-report.txt`, `comparison.json` — reports
+- `old/`, `new/` — downloaded RDS references
+- `old/generated/`, `new/generated/` — PolicyGenerator output
+- `old-extracted/`, `new-extracted/` — normalized CRs used for diff
+
+If `RDS_ARTIFACTS_BASE_URL` is set, the response also includes **artifacts_base_url** with full URLs. In Kubernetes, use the same Route (or Ingress) host as for MCP; session dirs persist when `RDS_DIFF_WORK_DIR` is set to a PVC mount (see [Configuration](#configuration)).
 
 **Example prompts:**
 
@@ -469,6 +477,14 @@ Compare RDS configuration between telco-reference 4.18 and 4.20 using GitHub URL
 ```
 Run RDS version diff for https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-18/telco-ran/configuration and https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration
 ```
+
+**Accessing artifacts over HTTP:** When the server runs with HTTP transport, the tool response includes an **artifact_id** (e.g. `rds-diff-abc123-1710512345`). Download files using the same base URL as MCP:
+
+- `GET <base>/artifacts/<artifact_id>/diff-report.txt` — text diff report
+- `GET <base>/artifacts/<artifact_id>/comparison.json` — full comparison JSON
+- `GET <base>/artifacts/<artifact_id>/old/` and `.../new/` — browsable RDS sources and generated CRs
+
+Example: if the MCP server is at `https://mcp.example.com`, then `https://mcp.example.com/artifacts/rds-diff-abc123-1710512345/diff-report.txt` returns the report. The deploy includes a PVC so session dirs persist across pod restarts (see [Deployment](#deployment)).
 
 ## RDS (Reference Design Specification) Support
 
@@ -757,7 +773,8 @@ The server behavior can be customized using environment variables:
 | `KUBE_COMPARE_MCP_IMAGE_PULL_TIMEOUT` | Timeout for pulling container images (Go duration string) | `5m` |
 | `KUBE_COMPARE_MCP_HTTP_VALIDATION_TIMEOUT` | Timeout for validating HTTP/HTTPS reference URLs (Go duration string) | `10s` |
 | `KUBE_COMPARE_MCP_OCI_VALIDATION_TIMEOUT` | Timeout for validating OCI container image references (Go duration string) | `30s` |
-| `RDS_DIFF_WORK_DIR` | Base directory for RDS version diff session artifacts (downloads, generated policies, reports). If unset, uses OS temp dir. | (OS temp) |
+| `RDS_DIFF_WORK_DIR` | Base directory for RDS version diff session artifacts (downloads, generated policies, reports). In Kubernetes deploy, set to the PVC mount path (e.g. `/var/rds-diff-artifacts`) so artifacts persist across restarts and are served at `GET /artifacts/<artifact_id>/...`. If unset, uses OS temp dir. | (OS temp) |
+| `RDS_ARTIFACTS_BASE_URL` | Optional. When set (e.g. `https://mcp.example.com`), the RDS version diff tool returns full artifact URLs in the response (`artifacts_base_url` and links). Must be the same host that serves `/artifacts/`. | (unset) |
 
 **Example:**
 

--- a/cmd/kube-compare-mcp/main.go
+++ b/cmd/kube-compare-mcp/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/sakhoury/kube-compare-mcp/pkg/mcpserver"
+	"github.com/sakhoury/kube-compare-mcp/pkg/rdsdiff"
 )
 
 var version = "dev"
@@ -119,6 +121,13 @@ func runHTTPServer(s *mcp.Server, port int, logger *slog.Logger) {
 		_, _ = w.Write([]byte(`{"status":"ok"}`))
 	})
 
+	// Artifacts: serve RDS version diff session files at GET /artifacts/<session-id>/...
+	workDir := os.Getenv("RDS_DIFF_WORK_DIR")
+	if workDir == "" {
+		workDir = os.TempDir()
+	}
+	mux.Handle("/artifacts/", artifactsHandler(workDir))
+
 	// MCP endpoint handled by the Streamable HTTP handler
 	streamHandler := mcp.NewStreamableHTTPHandler(func(*http.Request) *mcp.Server { return s }, nil)
 	mux.Handle("/mcp", streamHandler)
@@ -155,6 +164,63 @@ func runHTTPServer(s *mcp.Server, port int, logger *slog.Logger) {
 		os.Exit(1)
 	}
 	logger.Info("Server stopped")
+}
+
+// artifactsHandler returns an http.Handler that serves session files under GET /artifacts/<session-id>/...
+// workDir is the RDS_DIFF_WORK_DIR (or OS temp). Path traversal is prevented via rdsdiff.ResolveSessionPath.
+func artifactsHandler(workDir string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		path := strings.TrimPrefix(r.URL.Path, "/artifacts")
+		path = strings.TrimPrefix(path, "/")
+		if path == "" {
+			http.Error(w, "missing session id", http.StatusBadRequest)
+			return
+		}
+		firstSlash := strings.Index(path, "/")
+		var sessionID, subpath string
+		if firstSlash < 0 {
+			sessionID = path
+			subpath = ""
+		} else {
+			sessionID = path[:firstSlash]
+			subpath = path[firstSlash+1:]
+		}
+		sessionPath, err := rdsdiff.ResolveSessionPath(workDir, sessionID)
+		if err != nil {
+			if errors.Is(err, rdsdiff.ErrInvalidSessionID) {
+				http.Error(w, "invalid session id", http.StatusBadRequest)
+				return
+			}
+			if os.IsNotExist(err) {
+				http.Error(w, "session not found", http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		// Serve from sessionPath; request path becomes subpath (or "/" for directory listing)
+		r2 := r.Clone(r.Context())
+		r2.URL = cloneURL(r.URL)
+		if subpath != "" {
+			r2.URL.Path = "/" + subpath
+		} else {
+			r2.URL.Path = "/"
+		}
+		http.FileServer(http.Dir(sessionPath)).ServeHTTP(w, r2)
+	})
+}
+
+func cloneURL(u *url.URL) *url.URL {
+	if u == nil {
+		return &url.URL{}
+	}
+	u2 := *u
+	return &u2
 }
 
 // loggingMiddleware wraps an http.Handler with request logging and body size limits.

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -33,6 +33,9 @@ spec:
             - --log-format=json
             - --log-level=debug
           env:
+            # RDS version diff artifacts persist under this directory (PVC mount)
+            - name: RDS_DIFF_WORK_DIR
+              value: /var/rds-diff-artifacts
             # Mount registry credentials for accessing private container registries
             # The secret should contain a .dockerconfigjson with credentials for registry.redhat.io
             - name: DOCKER_CONFIG
@@ -44,6 +47,8 @@ spec:
             # - name: KUBE_COMPARE_MCP_IMAGE_PULL_TIMEOUT
             #   value: "5m"  # Image pull timeout (default: 5 minutes)
           volumeMounts:
+            - name: rds-diff-artifacts
+              mountPath: /var/rds-diff-artifacts
             - name: registry-credentials
               mountPath: /etc/docker-credentials
               readOnly: true
@@ -82,13 +87,16 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
       volumes:
+        - name: rds-diff-artifacts
+          persistentVolumeClaim:
+            claimName: rds-diff-artifacts
         - name: registry-credentials
           secret:
             # Optional: Create this secret for RDS tools that access registry.redhat.io
             # Run: make setup-registry-credentials
             # Or manually create with your Red Hat registry pull secret
             secretName: registry-credentials
-            optional: true  # Allows deployment without the secret; RDS tools will fail until configured
+            optional: true # Allows deployment without the secret; RDS tools will fail until configured
             items:
               - key: .dockerconfigjson
                 path: config.json

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - serviceaccount.yaml
   - clusterrole.yaml
   - clusterrolebinding.yaml
+  - pvc.yaml
   - deployment.yaml
   - service.yaml
   - route.yaml

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -5,17 +5,19 @@ kind: Kustomization
 namespace: kube-compare-mcp
 
 resources:
-- namespace.yaml
-- serviceaccount.yaml
-- clusterrole.yaml
-- clusterrolebinding.yaml
-- deployment.yaml
-- service.yaml
-- route.yaml
+  - namespace.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - deployment.yaml
+  - service.yaml
+  - route.yaml
 
-commonLabels:
-  app.kubernetes.io/managed-by: kustomize
-  app.kubernetes.io/part-of: kube-compare-mcp
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/managed-by: kustomize
+      app.kubernetes.io/part-of: kube-compare-mcp
 
 # Customize the image using: kustomize edit set image
 # Example: kustomize edit set image quay.io/REPLACE_WITH_YOUR_USERNAME/kube-compare-mcp=quay.io/myuser/kube-compare-mcp:v1.0.0

--- a/deploy/pvc.yaml
+++ b/deploy/pvc.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# PersistentVolumeClaim for RDS version diff session artifacts.
+# Session dirs (downloads, generated policies, reports) persist across pod restarts.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rds-diff-artifacts
+  namespace: kube-compare-mcp
+  labels:
+    app.kubernetes.io/name: kube-compare-mcp
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  # storageClassName optional; use cluster default if omitted

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.25.7
 
 require (
 	github.com/adrg/strutil v0.3.1
+	github.com/google/go-cmp v0.7.0
 	github.com/google/go-containerregistry v0.21.1
 	github.com/google/jsonschema-go v0.4.2
 	github.com/modelcontextprotocol/go-sdk v1.3.1
@@ -48,7 +49,6 @@ require (
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gosimple/slug v1.15.0 // indirect

--- a/pkg/mcpserver/helpers.go
+++ b/pkg/mcpserver/helpers.go
@@ -29,6 +29,11 @@ func newToolResultError(errMsg string) *mcp.CallToolResult {
 	}
 }
 
+// newToolResultFormatError creates an error tool result with a user-friendly message from err.
+func newToolResultFormatError(err error) *mcp.CallToolResult {
+	return newToolResultError(formatErrorForUser(err))
+}
+
 // ptrBool returns a pointer to a bool value, used for optional annotation fields.
 func ptrBool(b bool) *bool {
 	return &b

--- a/pkg/mcpserver/interfaces.go
+++ b/pkg/mcpserver/interfaces.go
@@ -129,8 +129,9 @@ type DefaultHTTPDoer struct {
 }
 
 // Do performs an HTTP request using the underlying http.Client.
+// The request URL is validated by callers (e.g. validateRDSVersionDiffURLs) before Do.
 func (d *DefaultHTTPDoer) Do(req *http.Request) (*http.Response, error) {
-	resp, err := d.Client.Do(req)
+	resp, err := d.Client.Do(req) // #nosec G704 -- URL validated by caller
 	if err != nil {
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}

--- a/pkg/mcpserver/rds_version_diff.go
+++ b/pkg/mcpserver/rds_version_diff.go
@@ -22,7 +22,7 @@ import (
 func RDSVersionDiffTool() *mcp.Tool {
 	return &mcp.Tool{
 		Name:        "kube_compare_rds_version_diff",
-		Description: "Detect configuration differences between two RDS (telco reference) versions. Accepts two downloadable URLs (old and new; e.g. GitHub tree URLs or direct links to zip/tar.gz), downloads and extracts sources, runs the PolicyGenerator binary to generate policies, then compares and reports differences. Returns diff report and session artifact path.",
+		Description: "Detect configuration differences between two RDS (telco reference) versions. Accepts two downloadable URLs (old and new; e.g. GitHub tree URLs or direct links to zip/tar.gz), downloads and extracts sources, runs the PolicyGenerator binary to generate policies, then compares and reports differences. Returns diff report, artifact_id for HTTP download at GET /artifacts/<artifact_id>/..., and session path.",
 		InputSchema: RDSVersionDiffInputSchema(),
 	}
 }
@@ -40,6 +40,10 @@ type RDSVersionDiffOutput struct {
 	DiffReport string `json:"diff_report"`
 	// ArtifactsPath is the path to the session directory containing downloaded sources, generated CRs, and the diff report file.
 	ArtifactsPath string `json:"artifacts_path"`
+	// ArtifactID is the session directory name; use with GET /artifacts/<artifact_id>/... to download files.
+	ArtifactID string `json:"artifact_id"`
+	// ArtifactsBaseURL is set when RDS_ARTIFACTS_BASE_URL env is set; base URL for artifact HTTP access (e.g. https://host/artifacts/<artifact_id>/).
+	ArtifactsBaseURL string `json:"artifacts_base_url,omitempty"`
 }
 
 // HandleRDSVersionDiff is the MCP tool handler for kube_compare_rds_version_diff.
@@ -131,16 +135,30 @@ func HandleRDSVersionDiff(ctx context.Context, req *mcp.CallToolRequest, input R
 		fullReport = string(data)
 	}
 
-	body := summary + "\n\nArtifacts path: " + sessionDir
+	artifactID := rdsdiff.SessionID(sessionDir)
+	output = RDSVersionDiffOutput{
+		DiffReport:    fullReport,
+		ArtifactsPath: sessionDir,
+		ArtifactID:    artifactID,
+	}
+
+	body := summary + "\n\nArtifacts path: " + sessionDir + "\nArtifact ID: " + artifactID
+	body += "\n\nDownload files at: GET /artifacts/" + artifactID + "/"
+	body += "\n  Key paths: diff-report.txt, comparison.json, old/, new/, old/generated/, new/generated/, old-extracted/, new-extracted/"
+
+	baseURL := strings.TrimSuffix(strings.TrimSpace(os.Getenv("RDS_ARTIFACTS_BASE_URL")), "/")
+	if baseURL != "" {
+		output.ArtifactsBaseURL = baseURL + "/artifacts/" + artifactID + "/"
+		body += "\n\nArtifacts base URL: " + output.ArtifactsBaseURL
+		body += "\n  Reports: " + output.ArtifactsBaseURL + "diff-report.txt, " + output.ArtifactsBaseURL + "comparison.json"
+		body += "\n  RDS sources: " + output.ArtifactsBaseURL + "old/, " + output.ArtifactsBaseURL + "new/"
+	}
+
 	if fullReport != "" {
 		body += "\n\n--- Diff report ---\n" + fullReport
 	}
 
-	logger.Info("RDS version diff completed", "sessionDir", sessionDir)
-	output = RDSVersionDiffOutput{
-		DiffReport:    fullReport,
-		ArtifactsPath: sessionDir,
-	}
+	logger.Info("RDS version diff completed", "sessionDir", sessionDir, "artifactID", artifactID)
 	return newToolResultText(body), output, nil
 }
 

--- a/pkg/mcpserver/rds_version_diff.go
+++ b/pkg/mcpserver/rds_version_diff.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpserver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/sakhoury/kube-compare-mcp/pkg/rdsdiff"
+)
+
+// RDSVersionDiffTool returns the MCP tool definition for rds-version-diff.
+func RDSVersionDiffTool() *mcp.Tool {
+	return &mcp.Tool{
+		Name:        "kube_compare_rds_version_diff",
+		Description: "Detect configuration differences between two RDS (telco reference) versions. Accepts two downloadable URLs (old and new; e.g. GitHub tree URLs or direct links to zip/tar.gz), downloads and extracts sources, runs the PolicyGenerator binary to generate policies, then compares and reports differences. Returns diff report and session artifact path.",
+		InputSchema: RDSVersionDiffInputSchema(),
+	}
+}
+
+// RDSVersionDiffInput is the typed input for the RDS version diff tool.
+type RDSVersionDiffInput struct {
+	OldVersionURL string `json:"old_version_url" jsonschema:"URL for the older telco reference (e.g. GitHub tree URL or direct link to a zip/tar.gz archive). Must be downloadable via HTTP GET."`
+	NewVersionURL string `json:"new_version_url" jsonschema:"URL for the newer telco reference (e.g. GitHub tree URL or direct link to a zip/tar.gz archive). Must be downloadable via HTTP GET."`
+	WorkDir       string `json:"work_dir,omitempty" jsonschema:"Optional base directory for session artifacts; defaults to RDS_DIFF_WORK_DIR env or OS temp"`
+}
+
+// RDSVersionDiffOutput is the typed output for the RDS version diff tool (for handler signature consistency).
+type RDSVersionDiffOutput struct {
+	// DiffReport is the full diff report text (generated CRs comparison).
+	DiffReport string `json:"diff_report"`
+	// ArtifactsPath is the path to the session directory containing downloaded sources, generated CRs, and the diff report file.
+	ArtifactsPath string `json:"artifacts_path"`
+}
+
+// HandleRDSVersionDiff is the MCP tool handler for kube_compare_rds_version_diff.
+func HandleRDSVersionDiff(ctx context.Context, req *mcp.CallToolRequest, input RDSVersionDiffInput) (toolResult *mcp.CallToolResult, output RDSVersionDiffOutput, toolErr error) {
+	requestID := generateRequestID()
+	logger := slog.Default().With("requestID", requestID)
+
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("Panic recovered in RDS version diff handler", "panic", r, "stackTrace", string(debug.Stack()))
+			toolResult = newToolResultError(fmt.Sprintf("Internal error: %v", r))
+		}
+	}()
+
+	if err := ctx.Err(); err != nil {
+		logger.Warn("Request canceled", "error", err)
+		return newToolResultFormatError(ErrContextCanceled), RDSVersionDiffOutput{}, nil
+	}
+
+	oldURL := strings.TrimSpace(input.OldVersionURL)
+	newURL := strings.TrimSpace(input.NewVersionURL)
+	if err := validateRDSVersionDiffURLs(oldURL, newURL); err != nil {
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	workDir := resolveWorkDir(input.WorkDir)
+	sessionDir, err := rdsdiff.SessionDir(workDir, requestID)
+	if err != nil {
+		logger.Error("Create session dir failed", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	oldDest := filepath.Join(sessionDir, "old")
+	newDest := filepath.Join(sessionDir, "new")
+	if err := os.MkdirAll(oldDest, 0750); err != nil {
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+	if err := os.MkdirAll(newDest, 0750); err != nil {
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	client := &http.Client{Timeout: rdsdiff.DefaultDownloadTimeout}
+	oldRoot, err := rdsdiff.DownloadURL(oldURL, oldDest, client)
+	if err != nil {
+		logger.Error("Download old version failed", "error", err, "url", oldURL)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+	if err := rdsdiff.ValidateConfigurationRoot(oldRoot); err != nil {
+		logger.Error("Old version missing configuration layout", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	newRoot, err := rdsdiff.DownloadURL(newURL, newDest, client)
+	if err != nil {
+		logger.Error("Download new version failed", "error", err, "url", newURL)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+	if err := rdsdiff.ValidateConfigurationRoot(newRoot); err != nil {
+		logger.Error("New version missing configuration layout", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	policyGenPath, err := resolvePolicyGeneratorPath()
+	if err != nil {
+		logger.Error("PolicyGenerator binary not found", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	oldGenerated := filepath.Join(sessionDir, "old", "generated")
+	newGenerated := filepath.Join(sessionDir, "new", "generated")
+	if err := rdsdiff.RunPolicyGen(oldRoot, policyGenPath, oldGenerated); err != nil {
+		logger.Error("PolicyGen for old version failed", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+	if err := rdsdiff.RunPolicyGen(newRoot, policyGenPath, newGenerated); err != nil {
+		logger.Error("PolicyGen for new version failed", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	summary, err := rdsdiff.RunCompare(oldGenerated, newGenerated, sessionDir)
+	if err != nil {
+		logger.Error("RDS version compare failed", "error", err)
+		return newToolResultFormatError(err), RDSVersionDiffOutput{}, nil
+	}
+
+	reportPath := filepath.Join(sessionDir, "diff-report.txt")
+	fullReport := ""
+	if data, err := os.ReadFile(reportPath); err == nil { // #nosec G304 -- reportPath is under sessionDir we created
+		fullReport = string(data)
+	}
+
+	body := summary + "\n\nArtifacts path: " + sessionDir
+	if fullReport != "" {
+		body += "\n\n--- Diff report ---\n" + fullReport
+	}
+
+	logger.Info("RDS version diff completed", "sessionDir", sessionDir)
+	output = RDSVersionDiffOutput{
+		DiffReport:    fullReport,
+		ArtifactsPath: sessionDir,
+	}
+	return newToolResultText(body), output, nil
+}
+
+func validateRDSVersionDiffURLs(oldURL, newURL string) *ValidationError {
+	if oldURL == "" {
+		return NewValidationError("old_version_url", "old_version_url is required", "Provide a downloadable URL (e.g. GitHub tree URL or direct link to zip/tar.gz).")
+	}
+	if newURL == "" {
+		return NewValidationError("new_version_url", "new_version_url is required", "Provide a downloadable URL (e.g. GitHub tree URL or direct link to zip/tar.gz).")
+	}
+	// Basic URL shape check; actual download is attempted in the handler.
+	if u, err := url.Parse(oldURL); err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+		return NewValidationError("old_version_url", "invalid or unsupported URL", "Use an https or http URL that points to a downloadable archive or GitHub tree.")
+	}
+	if u, err := url.Parse(newURL); err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+		return NewValidationError("new_version_url", "invalid or unsupported URL", "Use an https or http URL that points to a downloadable archive or GitHub tree.")
+	}
+	return nil
+}
+
+func resolveWorkDir(workDir string) string {
+	workDir = strings.TrimSpace(workDir)
+	if workDir != "" {
+		return filepath.Clean(workDir)
+	}
+	if d := os.Getenv("RDS_DIFF_WORK_DIR"); d != "" {
+		return filepath.Clean(d)
+	}
+	return os.TempDir()
+}
+
+// resolvePolicyGeneratorPath returns the path to the PolicyGenerator binary from POLICY_GENERATOR_BINARY_PATH env, or an error if unset/not found/not executable.
+func resolvePolicyGeneratorPath() (string, error) {
+	p, ok := os.LookupEnv("POLICY_GENERATOR_BINARY_PATH")
+	if !ok {
+		return "", fmt.Errorf("environment variable POLICY_GENERATOR_BINARY_PATH is not set")
+	}
+	p = filepath.Clean(strings.TrimSpace(p))
+	if _, err := os.Stat(p); err != nil {
+		return "", fmt.Errorf("stat policyGenerator binary: %w", err)
+	}
+	return p, nil
+}

--- a/pkg/mcpserver/rds_version_diff_test.go
+++ b/pkg/mcpserver/rds_version_diff_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package mcpserver_test
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sakhoury/kube-compare-mcp/pkg/mcpserver"
+)
+
+var _ = Describe("RDS version diff", func() {
+	Describe("HandleRDSVersionDiff", func() {
+		It("returns error when old_version_url is missing", func() {
+			ctx := context.Background()
+			req := NewMCPRequest(nil)
+			input := mcpserver.RDSVersionDiffInput{
+				NewVersionURL: "https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration",
+			}
+			result, _, err := mcpserver.HandleRDSVersionDiff(ctx, req, input)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(result.IsError).To(BeTrue())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(ContainSubstring("old_version_url"))
+		})
+		It("returns error when new_version_url is missing", func() {
+			ctx := context.Background()
+			req := NewMCPRequest(nil)
+			input := mcpserver.RDSVersionDiffInput{
+				OldVersionURL: "https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-18/telco-ran/configuration",
+			}
+			result, _, err := mcpserver.HandleRDSVersionDiff(ctx, req, input)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(result.IsError).To(BeTrue())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(ContainSubstring("new_version_url"))
+		})
+		It("returns error when old_version_url has unsupported scheme", func() {
+			ctx := context.Background()
+			req := NewMCPRequest(nil)
+			input := mcpserver.RDSVersionDiffInput{
+				OldVersionURL: "ftp://example.com/archive.zip",
+				NewVersionURL: "https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration",
+			}
+			result, _, err := mcpserver.HandleRDSVersionDiff(ctx, req, input)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(result.IsError).To(BeTrue())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(ContainSubstring("old_version_url"))
+		})
+		It("returns error when new_version_url is invalid", func() {
+			ctx := context.Background()
+			req := NewMCPRequest(nil)
+			input := mcpserver.RDSVersionDiffInput{
+				OldVersionURL: "https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-18/telco-ran/configuration",
+				NewVersionURL: "not-a-url",
+			}
+			result, _, err := mcpserver.HandleRDSVersionDiff(ctx, req, input)
+			Expect(err).To(BeNil())
+			Expect(result).NotTo(BeNil())
+			Expect(result.IsError).To(BeTrue())
+			textContent, ok := result.Content[0].(*mcp.TextContent)
+			Expect(ok).To(BeTrue())
+			Expect(textContent.Text).To(ContainSubstring("new_version_url"))
+		})
+	})
+})

--- a/pkg/mcpserver/schema.go
+++ b/pkg/mcpserver/schema.go
@@ -126,3 +126,12 @@ func BIOSDiffOutputSchema() *jsonschema.Schema {
 
 	return schema
 }
+
+// RDSVersionDiffInputSchema returns the JSON schema for RDSVersionDiffInput.
+func RDSVersionDiffInputSchema() *jsonschema.Schema {
+	schema, err := jsonschema.For[RDSVersionDiffInput](nil)
+	if err != nil {
+		panic(err) // Fails at startup, not during request handling
+	}
+	return schema
+}

--- a/pkg/mcpserver/server.go
+++ b/pkg/mcpserver/server.go
@@ -33,11 +33,12 @@ func NewServer(version string) *mcp.Server {
 	mcp.AddTool(s, ResolveRDSTool(), HandleResolveRDS)
 	mcp.AddTool(s, ValidateRDSTool(), HandleValidateRDS)
 	mcp.AddTool(s, BIOSDiffTool(), HandleBIOSDiff)
+	mcp.AddTool(s, RDSVersionDiffTool(), HandleRDSVersionDiff)
 
 	logger.Info("MCP server initialized",
 		"name", ServerName,
 		"version", version,
-		"tools", []string{"kube_compare_cluster_diff", "kube_compare_resolve_rds", "kube_compare_validate_rds", "baremetal_bios_diff"},
+		"tools", []string{"kube_compare_cluster_diff", "kube_compare_resolve_rds", "kube_compare_validate_rds", "baremetal_bios_diff", "kube_compare_rds_version_diff"},
 	)
 
 	return s

--- a/pkg/rdsdiff/compare.go
+++ b/pkg/rdsdiff/compare.go
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+var slashRe = regexp.MustCompile(`/+`)
+
+// CRKeyFromObject builds a stable key for a CR: kind_namespace_name, or kind_name for cluster-scoped.
+func CRKeyFromObject(obj map[string]interface{}) string {
+	kind, _ := obj["kind"].(string)
+	if kind == "" {
+		kind = "Unknown"
+	}
+	meta, _ := obj["metadata"].(map[string]interface{})
+	if meta == nil {
+		meta = make(map[string]interface{})
+	}
+	name, _ := meta["name"].(string)
+	if name == "" {
+		name = "unnamed"
+	}
+	ns, _ := meta["namespace"].(string)
+	var key string
+	if ns == "" {
+		key = kind + "_" + name
+	} else {
+		key = kind + "_" + ns + "_" + name
+	}
+	return slashRe.ReplaceAllString(key, "-")
+}
+
+// CRPair is a key and object pair from a Policy document.
+type CRPair struct {
+	Key string
+	Obj map[string]interface{}
+}
+
+// ExtractCRsFromPolicyDoc returns CRPair for each CR embedded in a Policy document.
+func ExtractCRsFromPolicyDoc(doc map[string]interface{}) []CRPair {
+	if kind, _ := doc["kind"].(string); kind != "Policy" {
+		return nil
+	}
+	var out []CRPair
+	spec, _ := doc["spec"].(map[string]interface{})
+	if spec == nil {
+		return nil
+	}
+	templates, _ := spec["policy-templates"].([]interface{})
+	for _, t := range templates {
+		tm, _ := t.(map[string]interface{})
+		if tm == nil {
+			continue
+		}
+		od, _ := tm["objectDefinition"].(map[string]interface{})
+		if od == nil {
+			continue
+		}
+		innerSpec, _ := od["spec"].(map[string]interface{})
+		if innerSpec == nil {
+			continue
+		}
+		objTemplates, _ := innerSpec["object-templates"].([]interface{})
+		for _, ot := range objTemplates {
+			otm, _ := ot.(map[string]interface{})
+			if otm == nil {
+				continue
+			}
+			obj, _ := otm["objectDefinition"].(map[string]interface{})
+			if obj == nil {
+				continue
+			}
+			key := CRKeyFromObject(obj)
+			out = append(out, CRPair{Key: key, Obj: obj})
+		}
+	}
+	return out
+}
+
+// ExtractCRs reads all *.yaml in generatedDir, collects CRs from Policy files, writes extractedDir with one file per key.
+func ExtractCRs(generatedDir, extractedDir string) error {
+	generatedDir = filepath.Clean(generatedDir)
+	extractedDir = filepath.Clean(extractedDir)
+	if err := os.MkdirAll(extractedDir, 0750); err != nil {
+		return fmt.Errorf("mkdir extracted dir: %w", err)
+	}
+	entries, err := os.ReadDir(generatedDir)
+	if err != nil {
+		return fmt.Errorf("read generated dir: %w", err)
+	}
+	collected := make(map[string]map[string]interface{})
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".yaml") {
+			continue
+		}
+		path := filepath.Join(generatedDir, e.Name())
+		data, err := os.ReadFile(path) // #nosec G304 -- path from ReadDir under generatedDir
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		docs := unmarshalMultiDocYAML(data)
+		for _, doc := range docs {
+			if doc == nil {
+				continue
+			}
+			for _, pair := range ExtractCRsFromPolicyDoc(doc) {
+				collected[pair.Key] = pair.Obj
+			}
+		}
+	}
+	keys := make([]string, 0, len(collected))
+	for k := range collected {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		norm, err := normalizeYAML(collected[key])
+		if err != nil {
+			return err
+		}
+		outPath := filepath.Join(extractedDir, key+".yaml")
+		if err := os.WriteFile(outPath, []byte(norm), 0600); err != nil {
+			return fmt.Errorf("write %s: %w", outPath, err)
+		}
+	}
+	return nil
+}
+
+func unmarshalMultiDocYAML(data []byte) []map[string]interface{} {
+	var docs []map[string]interface{}
+	parts := strings.Split(string(data), "\n---")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		var doc map[string]interface{}
+		if err := sigsyaml.Unmarshal([]byte(part), &doc); err != nil {
+			continue
+		}
+		if doc != nil {
+			docs = append(docs, doc)
+		}
+	}
+	if len(docs) == 0 {
+		var single map[string]interface{}
+		if err := sigsyaml.Unmarshal(data, &single); err == nil && single != nil {
+			docs = []map[string]interface{}{single}
+		}
+	}
+	return docs
+}
+
+func getKeysFromExtractedDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read dir %s: %w", dir, err)
+	}
+	var keys []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(strings.ToLower(name), ".yaml") {
+			keys = append(keys, strings.TrimSuffix(name, filepath.Ext(name)))
+		}
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+// GetKeysFromExtractedDir returns sorted list of CR keys (filename stem without .yaml). Exported for testing.
+func GetKeysFromExtractedDir(dir string) ([]string, error) {
+	return getKeysFromExtractedDir(dir)
+}
+
+// Correlate returns onlyOld, onlyNew, inBoth key lists (all sorted). Exported for testing.
+func Correlate(oldDir, newDir string) (onlyOld, onlyNew, inBoth []string, err error) {
+	return correlate(oldDir, newDir)
+}
+
+// NormalizeYAML marshals obj with sorted keys for stable diff. Exported for testing.
+func NormalizeYAML(obj map[string]interface{}) (string, error) {
+	return normalizeYAML(obj)
+}
+
+// ComputeDiff loads both YAMLs, normalizes them, returns unified diff text. Exported for testing.
+func ComputeDiff(oldPath, newPath string) (string, error) {
+	return computeDiff(oldPath, newPath)
+}
+
+// BuildSummary builds the summary block text. Exported for testing.
+func BuildSummary(onlyOld, onlyNew, inBoth []string, numDiffer int) string {
+	return buildSummary(onlyOld, onlyNew, inBoth, numDiffer)
+}
+
+func correlate(oldDir, newDir string) (onlyOld, onlyNew, inBoth []string, err error) {
+	oldKeys, err := getKeysFromExtractedDir(oldDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	newKeys, err := getKeysFromExtractedDir(newDir)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	oldSet := make(map[string]struct{})
+	for _, k := range oldKeys {
+		oldSet[k] = struct{}{}
+	}
+	newSet := make(map[string]struct{})
+	for _, k := range newKeys {
+		newSet[k] = struct{}{}
+	}
+	for _, k := range oldKeys {
+		if _, in := newSet[k]; !in {
+			onlyOld = append(onlyOld, k)
+		} else {
+			inBoth = append(inBoth, k)
+		}
+	}
+	for _, k := range newKeys {
+		if _, in := oldSet[k]; !in {
+			onlyNew = append(onlyNew, k)
+		}
+	}
+	sort.Strings(onlyOld)
+	sort.Strings(onlyNew)
+	sort.Strings(inBoth)
+	return onlyOld, onlyNew, inBoth, nil
+}
+
+func sortMapKeys(m map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(m))
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := m[k]
+		if vm, ok := v.(map[string]interface{}); ok {
+			out[k] = sortMapKeys(vm)
+		} else if vm, ok := v.([]interface{}); ok {
+			out[k] = sortSlice(vm)
+		} else {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func sortSlice(s []interface{}) []interface{} {
+	out := make([]interface{}, len(s))
+	for i, v := range s {
+		if vm, ok := v.(map[string]interface{}); ok {
+			out[i] = sortMapKeys(vm)
+		} else if vm, ok := v.([]interface{}); ok {
+			out[i] = sortSlice(vm)
+		} else {
+			out[i] = v
+		}
+	}
+	return out
+}
+
+func normalizeYAML(obj map[string]interface{}) (string, error) {
+	sorted := sortMapKeys(obj)
+	b, err := sigsyaml.Marshal(sorted)
+	if err != nil {
+		return "", fmt.Errorf("marshal yaml: %w", err)
+	}
+	return string(b), nil
+}
+
+func computeDiff(oldPath, newPath string) (string, error) {
+	oldData, err := os.ReadFile(oldPath) // #nosec G304 -- path from filepath.Join(extractedDir, key)
+	if err != nil {
+		return "", fmt.Errorf("read old %s: %w", oldPath, err)
+	}
+	newData, err := os.ReadFile(newPath) // #nosec G304 -- path from filepath.Join(extractedDir, key)
+	if err != nil {
+		return "", fmt.Errorf("read new %s: %w", newPath, err)
+	}
+	var oldObj, newObj map[string]interface{}
+	if err := sigsyaml.Unmarshal(oldData, &oldObj); err != nil {
+		oldObj = nil
+	}
+	if err := sigsyaml.Unmarshal(newData, &newObj); err != nil {
+		newObj = nil
+	}
+	if oldObj == nil {
+		oldObj = make(map[string]interface{})
+	}
+	if newObj == nil {
+		newObj = make(map[string]interface{})
+	}
+	oldStr, err := normalizeYAML(oldObj)
+	if err != nil {
+		return "", fmt.Errorf("normalize old: %w", err)
+	}
+	newStr, err := normalizeYAML(newObj)
+	if err != nil {
+		return "", fmt.Errorf("normalize new: %w", err)
+	}
+	return unifiedDiff(oldStr, newStr, filepath.Base(oldPath), filepath.Base(newPath)), nil
+}
+
+func unifiedDiff(oldStr, newStr, fromFile, toFile string) string {
+	oldLines := strings.Split(oldStr, "\n")
+	newLines := strings.Split(newStr, "\n")
+	diff := cmp.Diff(oldLines, newLines)
+	if diff == "" {
+		return ""
+	}
+	return "--- " + fromFile + "\n+++ " + toFile + "\n" + diff
+}
+
+func buildSummary(onlyOld, onlyNew, inBoth []string, numDiffer int) string {
+	return fmt.Sprintf("Comparison summary\n==================\nOnly in old:  %d\nOnly in new: %d\nIn both:       %d\nDiffer:        %d\n\n",
+		len(onlyOld), len(onlyNew), len(inBoth), numDiffer)
+}
+
+// ComparisonJSON is the shape of the comparison JSON file.
+type ComparisonJSON struct {
+	OnlyOld      []string               `json:"only_old"`
+	OnlyNew      []string               `json:"only_new"`
+	InBoth       []string               `json:"in_both"`
+	Diffs        map[string]CRDiffEntry `json:"diffs"`
+	Summary      string                 `json:"summary"`
+	OldExtracted string                 `json:"old_extracted"`
+	NewExtracted string                 `json:"new_extracted"`
+}
+
+// CRDiffEntry holds old/new content and diff text for one CR key.
+type CRDiffEntry struct {
+	OldContent string `json:"old_content"`
+	NewContent string `json:"new_content"`
+	DiffText   string `json:"diff_text"`
+}
+
+// RunCompare performs correlate, diff, writes report and comparison JSON under sessionDir; returns summary.
+// oldGenerated and newGenerated are the generated policy dirs; report and JSON are written to sessionDir.
+func RunCompare(oldGenerated, newGenerated, sessionDir string) (summary string, err error) {
+	oldGenerated = filepath.Clean(oldGenerated)
+	newGenerated = filepath.Clean(newGenerated)
+	sessionDir = filepath.Clean(sessionDir)
+	oldExtracted := filepath.Join(sessionDir, "old-extracted")
+	newExtracted := filepath.Join(sessionDir, "new-extracted")
+	if err := os.MkdirAll(oldExtracted, 0750); err != nil {
+		return "", fmt.Errorf("mkdir old-extracted: %w", err)
+	}
+	if err := os.MkdirAll(newExtracted, 0750); err != nil {
+		return "", fmt.Errorf("mkdir new-extracted: %w", err)
+	}
+	if err := ExtractCRs(oldGenerated, oldExtracted); err != nil {
+		return "", fmt.Errorf("extract old: %w", err)
+	}
+	if err := ExtractCRs(newGenerated, newExtracted); err != nil {
+		return "", fmt.Errorf("extract new: %w", err)
+	}
+	reportPath := filepath.Join(sessionDir, "diff-report.txt")
+	comparisonJSONPath := filepath.Join(sessionDir, "comparison.json")
+	return Run(oldExtracted, newExtracted, reportPath, comparisonJSONPath)
+}
+
+// Run performs correlate, diff, writes report and comparison JSON; returns summary.
+func Run(oldExtracted, newExtracted, reportPath, comparisonJSONPath string) (summary string, err error) {
+	oldExtracted = filepath.Clean(oldExtracted)
+	newExtracted = filepath.Clean(newExtracted)
+	reportPath = filepath.Clean(reportPath)
+	comparisonJSONPath = filepath.Clean(comparisonJSONPath)
+
+	onlyOld, onlyNew, inBoth, err := correlate(oldExtracted, newExtracted)
+	if err != nil {
+		return "", fmt.Errorf("correlate: %w", err)
+	}
+
+	diffs := make(map[string]CRDiffEntry)
+	numDiffer := 0
+	for _, key := range inBoth {
+		oldPath := filepath.Join(oldExtracted, key+".yaml")
+		newPath := filepath.Join(newExtracted, key+".yaml")
+		diffText, err := computeDiff(oldPath, newPath)
+		if err != nil {
+			return "", fmt.Errorf("diff %s: %w", key, err)
+		}
+		oldContent, _ := os.ReadFile(oldPath) // #nosec G304 -- path from filepath.Join(extractedDir, key)
+		newContent, _ := os.ReadFile(newPath) // #nosec G304 -- path from filepath.Join(extractedDir, key)
+		diffs[key] = CRDiffEntry{
+			OldContent: string(oldContent),
+			NewContent: string(newContent),
+			DiffText:   diffText,
+		}
+		if strings.TrimSpace(diffText) != "" {
+			numDiffer++
+		}
+	}
+
+	summary = buildSummary(onlyOld, onlyNew, inBoth, numDiffer)
+
+	reportLines := []string{summary, ""}
+	for _, key := range inBoth {
+		if strings.TrimSpace(diffs[key].DiffText) != "" {
+			reportLines = append(reportLines, "--- "+key+" ---", diffs[key].DiffText, "")
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(reportPath), 0750); err != nil {
+		return "", fmt.Errorf("mkdir report dir: %w", err)
+	}
+	if err := os.WriteFile(reportPath, []byte(strings.Join(reportLines, "\n")), 0600); err != nil {
+		return "", fmt.Errorf("write report: %w", err)
+	}
+
+	comparison := ComparisonJSON{
+		OnlyOld:      onlyOld,
+		OnlyNew:      onlyNew,
+		InBoth:       inBoth,
+		Diffs:        diffs,
+		Summary:      summary,
+		OldExtracted: oldExtracted,
+		NewExtracted: newExtracted,
+	}
+	comparisonBytes, err := json.MarshalIndent(comparison, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal comparison: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(comparisonJSONPath), 0750); err != nil {
+		return "", fmt.Errorf("mkdir comparison dir: %w", err)
+	}
+	if err := os.WriteFile(comparisonJSONPath, comparisonBytes, 0600); err != nil {
+		return "", fmt.Errorf("write comparison: %w", err)
+	}
+	return summary, nil
+}

--- a/pkg/rdsdiff/compare_test.go
+++ b/pkg/rdsdiff/compare_test.go
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/sakhoury/kube-compare-mcp/pkg/rdsdiff"
+)
+
+const minimalPolicyYAML = `
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: test-policy
+  namespace: ztp-common
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: test-config-policy
+        spec:
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: ConfigMap
+                metadata:
+                  name: my-config
+                  namespace: openshift-monitoring
+                data:
+                  key: value
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operator.openshift.io/v1alpha1
+                kind: ImageContentSourcePolicy
+                metadata:
+                  name: my-icsp
+                spec:
+                  repositoryDigestMirrors: []
+`
+
+const policyWithDuplicateKey = `
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: dup-policy
+  namespace: ztp-common
+spec:
+  policy-templates:
+    - objectDefinition:
+        spec:
+          object-templates:
+            - objectDefinition:
+                kind: ConfigMap
+                metadata:
+                  name: same-name
+                  namespace: ns1
+                data:
+                  first: a
+            - objectDefinition:
+                kind: ConfigMap
+                metadata:
+                  name: same-name
+                  namespace: ns1
+                data:
+                  second: b
+`
+
+var _ = Describe("rdsdiff compare", func() {
+	Describe("GetKeysFromExtractedDir", func() {
+		It("returns empty for empty or missing dir", func() {
+			dir, err := os.MkdirTemp("", "rds-keys-empty")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dir)
+			keys, err := rdsdiff.GetKeysFromExtractedDir(dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).To(BeEmpty())
+
+			keys, err = rdsdiff.GetKeysFromExtractedDir(filepath.Join(dir, "nonexistent"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).To(BeEmpty())
+		})
+		It("returns stem of each .yaml file", func() {
+			dir, err := os.MkdirTemp("", "rds-keys")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dir)
+			Expect(os.WriteFile(filepath.Join(dir, "ConfigMap_ns_foo.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "Secret_ns_bar.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "readme.txt"), []byte("x"), 0600)).To(Succeed())
+			keys, err := rdsdiff.GetKeysFromExtractedDir(dir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keys).To(ConsistOf("ConfigMap_ns_foo", "Secret_ns_bar"))
+		})
+	})
+
+	Describe("Correlate", func() {
+		It("splits keys into onlyOld, onlyNew, inBoth sorted", func() {
+			oldDir, _ := os.MkdirTemp("", "rds-old")
+			defer os.RemoveAll(oldDir)
+			newDir, _ := os.MkdirTemp("", "rds-new")
+			defer os.RemoveAll(newDir)
+			Expect(os.WriteFile(filepath.Join(oldDir, "OnlyOld.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "OnlyNew.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldDir, "Both.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "Both.yaml"), []byte("{}"), 0600)).To(Succeed())
+			onlyOld, onlyNew, inBoth, err := rdsdiff.Correlate(oldDir, newDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(onlyOld).To(Equal([]string{"OnlyOld"}))
+			Expect(onlyNew).To(Equal([]string{"OnlyNew"}))
+			Expect(inBoth).To(Equal([]string{"Both"}))
+		})
+		It("returns inBoth sorted", func() {
+			oldDir, _ := os.MkdirTemp("", "rds-old")
+			defer os.RemoveAll(oldDir)
+			newDir, _ := os.MkdirTemp("", "rds-new")
+			defer os.RemoveAll(newDir)
+			for _, name := range []string{"Z", "A", "M"} {
+				Expect(os.WriteFile(filepath.Join(oldDir, name+".yaml"), []byte("{}"), 0600)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(newDir, name+".yaml"), []byte("{}"), 0600)).To(Succeed())
+			}
+			_, _, inBoth, err := rdsdiff.Correlate(oldDir, newDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(inBoth).To(Equal([]string{"A", "M", "Z"}))
+		})
+	})
+
+	Describe("NormalizeYAML", func() {
+		It("produces deterministic YAML with sorted keys", func() {
+			obj := map[string]interface{}{"b": 2, "a": 1}
+			out, err := rdsdiff.NormalizeYAML(obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).To(ContainSubstring("a:"))
+			Expect(out).To(ContainSubstring("b:"))
+			aIdx := strings.Index(out, "a:")
+			bIdx := strings.Index(out, "b:")
+			Expect(aIdx).To(BeNumerically("<", bIdx))
+		})
+	})
+
+	Describe("ComputeDiff", func() {
+		It("produces empty or negligible diff for identical files", func() {
+			dir, _ := os.MkdirTemp("", "rds-diff")
+			defer os.RemoveAll(dir)
+			content := "key: value\n"
+			Expect(os.WriteFile(filepath.Join(dir, "a.yaml"), []byte(content), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "b.yaml"), []byte(content), 0600)).To(Succeed())
+			diff, err := rdsdiff.ComputeDiff(filepath.Join(dir, "a.yaml"), filepath.Join(dir, "b.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(diff == "" || (!strings.Contains(diff, "value1") && !strings.Contains(diff, "value2"))).To(BeTrue())
+		})
+		It("produces non-empty unified diff for different content", func() {
+			dir, _ := os.MkdirTemp("", "rds-diff")
+			defer os.RemoveAll(dir)
+			Expect(os.WriteFile(filepath.Join(dir, "a.yaml"), []byte("key: value1\n"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(dir, "b.yaml"), []byte("key: value2\n"), 0600)).To(Succeed())
+			diff, err := rdsdiff.ComputeDiff(filepath.Join(dir, "a.yaml"), filepath.Join(dir, "b.yaml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.Contains(diff, "value1") || strings.Contains(diff, "value2")).To(BeTrue())
+			Expect(strings.Contains(diff, "---") || strings.Contains(diff, "+++")).To(BeTrue())
+		})
+	})
+
+	Describe("BuildSummary", func() {
+		It("contains counts", func() {
+			s := rdsdiff.BuildSummary([]string{"a"}, []string{"b"}, []string{"c", "d"}, 1)
+			Expect(s).To(ContainSubstring("Only in old:  1"))
+			Expect(s).To(ContainSubstring("Only in new: 1"))
+			Expect(s).To(ContainSubstring("In both:       2"))
+			Expect(s).To(ContainSubstring("Differ:        1"))
+		})
+	})
+
+	Describe("Run", func() {
+		It("writes report and comparison JSON with correct shape", func() {
+			root, _ := os.MkdirTemp("", "rds-run")
+			defer os.RemoveAll(root)
+			oldDir := filepath.Join(root, "old")
+			newDir := filepath.Join(root, "new")
+			Expect(os.MkdirAll(oldDir, 0750)).To(Succeed())
+			Expect(os.MkdirAll(newDir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldDir, "Same.yaml"), []byte("x: 1\n"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "Same.yaml"), []byte("x: 1\n"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldDir, "OnlyO.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "OnlyN.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldDir, "Diff.yaml"), []byte("a: 1\n"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "Diff.yaml"), []byte("a: 2\n"), 0600)).To(Succeed())
+			reportPath := filepath.Join(root, "report.txt")
+			jsonPath := filepath.Join(root, "comparison.json")
+			summary, err := rdsdiff.Run(oldDir, newDir, reportPath, jsonPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(summary).To(ContainSubstring("Only in old:  1"))
+			Expect(summary).To(ContainSubstring("Only in new: 1"))
+			Expect(summary).To(ContainSubstring("In both:       2"))
+			reportData, err := os.ReadFile(reportPath) // #nosec G304 -- path under test root
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(reportData)).To(ContainSubstring("Comparison summary"))
+			jsonData, err := os.ReadFile(jsonPath) // #nosec G304 -- path under test root
+			Expect(err).NotTo(HaveOccurred())
+			var data rdsdiff.ComparisonJSON
+			Expect(json.Unmarshal(jsonData, &data)).To(Succeed())
+			Expect(data.OnlyOld).To(Equal([]string{"OnlyO"}))
+			Expect(data.OnlyNew).To(Equal([]string{"OnlyN"}))
+			Expect(data.InBoth).To(ConsistOf("Diff", "Same"))
+			Expect(data.Diffs).To(HaveKey("Diff"))
+			Expect(data.Diffs["Diff"].OldContent).NotTo(BeEmpty())
+			Expect(data.Diffs["Diff"].NewContent).NotTo(BeEmpty())
+			Expect(data.Diffs["Diff"].DiffText).NotTo(BeEmpty())
+			Expect(data.OldExtracted).To(Equal(oldDir))
+			Expect(data.NewExtracted).To(Equal(newDir))
+		})
+		It("creates parent dirs for report and JSON", func() {
+			root, _ := os.MkdirTemp("", "rds-run")
+			defer os.RemoveAll(root)
+			oldDir := filepath.Join(root, "old")
+			newDir := filepath.Join(root, "new")
+			Expect(os.MkdirAll(oldDir, 0750)).To(Succeed())
+			Expect(os.MkdirAll(newDir, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldDir, "K.yaml"), []byte("{}"), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newDir, "K.yaml"), []byte("{}"), 0600)).To(Succeed())
+			reportPath := filepath.Join(root, "out", "sub", "report.txt")
+			jsonPath := filepath.Join(root, "out", "sub", "comparison.json")
+			_, err := rdsdiff.Run(oldDir, newDir, reportPath, jsonPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reportPath).To(BeARegularFile())
+			Expect(jsonPath).To(BeARegularFile())
+		})
+		It("with no overlapping files writes valid report and JSON", func() {
+			root, _ := os.MkdirTemp("", "rds-run")
+			defer os.RemoveAll(root)
+			oldDir := filepath.Join(root, "old")
+			newDir := filepath.Join(root, "new")
+			Expect(os.MkdirAll(oldDir, 0750)).To(Succeed())
+			Expect(os.MkdirAll(newDir, 0750)).To(Succeed())
+			reportPath := filepath.Join(root, "report.txt")
+			jsonPath := filepath.Join(root, "comparison.json")
+			summary, err := rdsdiff.Run(oldDir, newDir, reportPath, jsonPath)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(summary).To(ContainSubstring("Only in old:  0"))
+			Expect(summary).To(ContainSubstring("In both:       0"))
+			jsonData, err := os.ReadFile(jsonPath) // #nosec G304 -- path under test root
+			Expect(err).NotTo(HaveOccurred())
+			var data rdsdiff.ComparisonJSON
+			Expect(json.Unmarshal(jsonData, &data)).To(Succeed())
+			Expect(data.OnlyOld).To(BeEmpty())
+			Expect(data.InBoth).To(BeEmpty())
+			Expect(data.Diffs).To(BeEmpty())
+		})
+	})
+
+	Describe("CRKeyFromObject", func() {
+		It("namespaced resource is kind_namespace_name", func() {
+			obj := map[string]interface{}{
+				"kind":     "ConfigMap",
+				"metadata": map[string]interface{}{"name": "foo", "namespace": "openshift-monitoring"},
+			}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("ConfigMap_openshift-monitoring_foo"))
+		})
+		It("cluster-scoped resource is kind_name only", func() {
+			obj := map[string]interface{}{
+				"kind":     "ImageContentSourcePolicy",
+				"metadata": map[string]interface{}{"name": "my-icsp"},
+			}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("ImageContentSourcePolicy_my-icsp"))
+		})
+		It("empty namespace is treated as cluster-scoped", func() {
+			obj := map[string]interface{}{
+				"kind":     "Resource",
+				"metadata": map[string]interface{}{"name": "x", "namespace": ""},
+			}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("Resource_x"))
+		})
+		It("sanitizes / to - in name", func() {
+			obj := map[string]interface{}{
+				"kind":     "Something",
+				"metadata": map[string]interface{}{"name": "a/b/c", "namespace": "ns"},
+			}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("Something_ns_a-b-c"))
+		})
+		It("missing kind uses Unknown", func() {
+			obj := map[string]interface{}{"metadata": map[string]interface{}{"name": "n", "namespace": "ns"}}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("Unknown_ns_n"))
+		})
+		It("missing name uses unnamed", func() {
+			obj := map[string]interface{}{"kind": "ConfigMap", "metadata": map[string]interface{}{"namespace": "ns"}}
+			Expect(rdsdiff.CRKeyFromObject(obj)).To(Equal("ConfigMap_ns_unnamed"))
+		})
+	})
+
+	Describe("ExtractCRsFromPolicyDoc", func() {
+		It("returns 2 CRs for minimal Policy YAML", func() {
+			var doc map[string]interface{}
+			Expect(sigsyaml.Unmarshal([]byte(minimalPolicyYAML), &doc)).To(Succeed())
+			result := rdsdiff.ExtractCRsFromPolicyDoc(doc)
+			Expect(result).To(HaveLen(2))
+			keys := make([]string, len(result))
+			for i, r := range result {
+				keys[i] = r.Key
+			}
+			Expect(keys).To(ContainElement("ConfigMap_openshift-monitoring_my-config"))
+			Expect(keys).To(ContainElement("ImageContentSourcePolicy_my-icsp"))
+		})
+		It("returns empty for non-Policy doc", func() {
+			doc := map[string]interface{}{"kind": "ConfigMap", "metadata": map[string]interface{}{}}
+			Expect(rdsdiff.ExtractCRsFromPolicyDoc(doc)).To(BeEmpty())
+		})
+		It("returns empty for Policy with no policy-templates", func() {
+			doc := map[string]interface{}{"kind": "Policy", "spec": map[string]interface{}{}}
+			Expect(rdsdiff.ExtractCRsFromPolicyDoc(doc)).To(BeEmpty())
+		})
+	})
+
+	Describe("ExtractCRs", func() {
+		It("writes one file per CR sorted by key", func() {
+			root, _ := os.MkdirTemp("", "rds-extract")
+			defer os.RemoveAll(root)
+			generated := filepath.Join(root, "generated")
+			extracted := filepath.Join(root, "extracted")
+			Expect(os.MkdirAll(generated, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(generated, "policies.yaml"), []byte(minimalPolicyYAML), 0600)).To(Succeed())
+			Expect(rdsdiff.ExtractCRs(generated, extracted)).To(Succeed())
+			entries, err := os.ReadDir(extracted)
+			Expect(err).NotTo(HaveOccurred())
+			names := make([]string, len(entries))
+			for i, e := range entries {
+				names[i] = e.Name()
+			}
+			Expect(names).To(ConsistOf("ConfigMap_openshift-monitoring_my-config.yaml", "ImageContentSourcePolicy_my-icsp.yaml"))
+		})
+		It("extracted content is valid YAML with correct kind and metadata", func() {
+			root, _ := os.MkdirTemp("", "rds-extract")
+			defer os.RemoveAll(root)
+			generated := filepath.Join(root, "generated")
+			extracted := filepath.Join(root, "extracted")
+			Expect(os.MkdirAll(generated, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(generated, "p.yaml"), []byte(minimalPolicyYAML), 0600)).To(Succeed())
+			Expect(rdsdiff.ExtractCRs(generated, extracted)).To(Succeed())
+			data, err := os.ReadFile(filepath.Join(extracted, "ConfigMap_openshift-monitoring_my-config.yaml")) // #nosec G304 -- path under test root
+			Expect(err).NotTo(HaveOccurred())
+			var obj map[string]interface{}
+			Expect(sigsyaml.Unmarshal(data, &obj)).To(Succeed())
+			Expect(obj["kind"]).To(Equal("ConfigMap"))
+			meta, _ := obj["metadata"].(map[string]interface{})
+			Expect(meta["name"]).To(Equal("my-config"))
+			Expect(meta["namespace"]).To(Equal("openshift-monitoring"))
+			dataMap, ok := obj["data"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(dataMap["key"]).To(Equal("value"))
+		})
+		It("duplicate key last wins", func() {
+			root, _ := os.MkdirTemp("", "rds-extract")
+			defer os.RemoveAll(root)
+			generated := filepath.Join(root, "generated")
+			extracted := filepath.Join(root, "extracted")
+			Expect(os.MkdirAll(generated, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(generated, "dup.yaml"), []byte(policyWithDuplicateKey), 0600)).To(Succeed())
+			Expect(rdsdiff.ExtractCRs(generated, extracted)).To(Succeed())
+			data, err := os.ReadFile(filepath.Join(extracted, "ConfigMap_ns1_same-name.yaml")) // #nosec G304 -- path under test root
+			Expect(err).NotTo(HaveOccurred())
+			var obj map[string]interface{}
+			Expect(sigsyaml.Unmarshal(data, &obj)).To(Succeed())
+			dataMap, ok := obj["data"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(dataMap["second"]).To(Equal("b"))
+			Expect(dataMap).NotTo(HaveKey("first"))
+		})
+		It("creates extracted dir if it does not exist", func() {
+			root, _ := os.MkdirTemp("", "rds-extract")
+			defer os.RemoveAll(root)
+			generated := filepath.Join(root, "generated")
+			extracted := filepath.Join(root, "extracted")
+			Expect(os.MkdirAll(generated, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(generated, "p.yaml"), []byte(minimalPolicyYAML), 0600)).To(Succeed())
+			_, err := os.Stat(extracted)
+			Expect(os.IsNotExist(err)).To(BeTrue())
+			Expect(rdsdiff.ExtractCRs(generated, extracted)).To(Succeed())
+			info, err := os.Stat(extracted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+	})
+
+	Describe("RunCompare", func() {
+		It("extracts from generated dirs and writes report and JSON to sessionDir", func() {
+			root, _ := os.MkdirTemp("", "rds-runcompare")
+			defer os.RemoveAll(root)
+			oldGen := filepath.Join(root, "old-gen")
+			newGen := filepath.Join(root, "new-gen")
+			Expect(os.MkdirAll(oldGen, 0750)).To(Succeed())
+			Expect(os.MkdirAll(newGen, 0750)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(oldGen, "p.yaml"), []byte(minimalPolicyYAML), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(newGen, "p.yaml"), []byte(minimalPolicyYAML), 0600)).To(Succeed())
+			sessionDir := filepath.Join(root, "session")
+			Expect(os.MkdirAll(sessionDir, 0750)).To(Succeed())
+			summary, err := rdsdiff.RunCompare(oldGen, newGen, sessionDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(summary).To(ContainSubstring("Comparison summary"))
+			Expect(filepath.Join(sessionDir, "diff-report.txt")).To(BeARegularFile())
+			Expect(filepath.Join(sessionDir, "comparison.json")).To(BeARegularFile())
+		})
+	})
+
+	Describe("Constants", func() {
+		It("CRSPath and SourceCRSPath and ListOfCRsForSNO are set", func() {
+			Expect(rdsdiff.CRSPath).To(Equal("argocd/example/acmpolicygenerator"))
+			Expect(rdsdiff.SourceCRSPath).To(Equal("source-crs"))
+			Expect(rdsdiff.ListOfCRsForSNO).To(ContainElement("acm-common-ranGen.yaml"))
+			Expect(rdsdiff.ListOfCRsForSNO).To(HaveLen(4))
+		})
+	})
+})

--- a/pkg/rdsdiff/constants.go
+++ b/pkg/rdsdiff/constants.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff
+
+// Paths under the telco-reference configuration root (e.g. telco-ran/configuration).
+const (
+	// CRSPath is the directory containing PolicyGenerator policy YAMLs and source-crs copy.
+	// Matches telco-reference: configuration/argocd/example/acmpolicygenerator
+	CRSPath       = "argocd/example/acmpolicygenerator"
+	SourceCRSPath = "source-crs"
+)
+
+// ListOfCRsForSNO is the list of SNO policy filenames used by PolicyGenerator.
+var ListOfCRsForSNO = []string{
+	"acm-common-ranGen.yaml",
+	"acm-example-sno-site.yaml",
+	"acm-group-du-sno-ranGen.yaml",
+	"acm-group-du-sno-validator-ranGen.yaml",
+}

--- a/pkg/rdsdiff/download.go
+++ b/pkg/rdsdiff/download.go
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// GitHubTreeURL holds parsed parts of a GitHub tree URL.
+// Format: https://github.com/<owner>/<repo>/tree/<branch>/<path>
+type GitHubTreeURL struct {
+	Owner  string
+	Repo   string
+	Branch string
+	Path   string // e.g. "telco-ran/configuration"
+}
+
+// DefaultDownloadTimeout is the HTTP client timeout for fetching archives.
+const DefaultDownloadTimeout = 5 * time.Minute
+
+// safeJoinPath joins destDir and name and returns an error if the result escapes destDir (zip-slip prevention).
+func safeJoinPath(destDir, name string) (string, error) {
+	clean := filepath.Clean(name)
+	if clean == "" || clean == "." {
+		return destDir, nil
+	}
+	if filepath.IsAbs(clean) || strings.Contains(clean, "..") {
+		return "", fmt.Errorf("unsafe path in archive: %s", name)
+	}
+	joined := filepath.Join(destDir, filepath.FromSlash(clean))
+	rel, err := filepath.Rel(destDir, joined)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf("path escapes destination: %s", name)
+	}
+	return joined, nil
+}
+
+// ParseGitHubTreeURL parses a full GitHub tree URL and returns owner, repo, branch, path.
+// Path may be empty if URL points to repo root. Returns error for non-GitHub or malformed URLs.
+// Uses net/url (standard library) for URL parsing and path segment extraction.
+//
+// Format: https://github.com/<owner>/<repo>/tree/<branch>/<path>
+func ParseGitHubTreeURL(raw string) (*GitHubTreeURL, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, errors.New("URL is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host != "github.com" {
+		return nil, errors.New("only https://github.com/.../tree/<branch>/<path> URLs are supported")
+	}
+	// u.Path is decoded, e.g. "/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration"
+	path := strings.Trim(u.Path, "/")
+	parts := strings.SplitN(path, "/", 6)
+	// need at least: owner, repo, "tree", branch (4 segments)
+	if len(parts) < 4 || parts[2] != "tree" {
+		return nil, errors.New("URL must match https://github.com/<owner>/<repo>/tree/<branch>/<path>")
+	}
+	owner, repo, branch := parts[0], parts[1], parts[3]
+	subPath := ""
+	if len(parts) > 4 {
+		subPath = strings.Join(parts[4:], "/")
+	}
+	return &GitHubTreeURL{
+		Owner:  owner,
+		Repo:   repo,
+		Branch: branch,
+		Path:   strings.TrimSuffix(subPath, "/"),
+	}, nil
+}
+
+// ArchiveURL returns the GitHub archive URL for this tree (branch only; path is applied after extract).
+func (g *GitHubTreeURL) ArchiveURL() string {
+	return fmt.Sprintf("https://github.com/%s/%s/archive/refs/heads/%s.zip", g.Owner, g.Repo, g.Branch)
+}
+
+// TopLevelDir is the single top-level directory inside the zip (GitHub uses <repo>-<branch>).
+func (g *GitHubTreeURL) TopLevelDir() string {
+	return g.Repo + "-" + g.Branch
+}
+
+// EffectiveRoot returns the path inside the extracted archive that is the configuration root.
+// Empty Path means repo root, so EffectiveRoot == TopLevelDir.
+func (g *GitHubTreeURL) EffectiveRoot(extractDir string) string {
+	if g.Path == "" {
+		return filepath.Join(extractDir, g.TopLevelDir())
+	}
+	return filepath.Join(extractDir, g.TopLevelDir(), filepath.FromSlash(g.Path))
+}
+
+// DownloadGitHubTree downloads the GitHub archive for the given tree URL, extracts it to destDir,
+// and returns the effective root path (extractDir/topLevel/path). destDir must exist.
+func DownloadGitHubTree(treeURL, destDir string, client *http.Client) (effectiveRoot string, err error) {
+	parsed, err := ParseGitHubTreeURL(treeURL)
+	if err != nil {
+		return "", fmt.Errorf("parse github tree URL: %w", err)
+	}
+	if client == nil {
+		client = &http.Client{Timeout: DefaultDownloadTimeout}
+	}
+	archiveURL := parsed.ArchiveURL()
+	resp, err := client.Get(archiveURL)
+	if err != nil {
+		return "", fmt.Errorf("download %s: %w", archiveURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download %s: status %s", archiveURL, resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read archive: %w", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("open zip: %w", err)
+	}
+	destDirClean := filepath.Clean(destDir)
+	for _, f := range zr.File {
+		name := f.Name
+		if f.FileInfo().IsDir() {
+			name = strings.TrimSuffix(name, "/")
+			if name == "" {
+				continue
+			}
+			dstPath, err := safeJoinPath(destDirClean, name)
+			if err != nil {
+				return "", err
+			}
+			if err := os.MkdirAll(dstPath, 0750); err != nil {
+				return "", fmt.Errorf("mkdir %s: %w", dstPath, err)
+			}
+			continue
+		}
+		dstPath, err := safeJoinPath(destDirClean, name)
+		if err != nil {
+			return "", err
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0750); err != nil {
+			return "", fmt.Errorf("mkdir parent of %s: %w", dstPath, err)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("open zip entry %s: %w", name, err)
+		}
+		dst, err := os.Create(dstPath) // #nosec G304 -- dstPath from safeJoinPath
+		if err != nil {
+			_ = rc.Close()
+			return "", fmt.Errorf("create %s: %w", dstPath, err)
+		}
+		_, err = io.Copy(dst, rc) // #nosec G110 -- size bounded by client timeout and typical archive size
+		_ = dst.Close()
+		_ = rc.Close()
+		if err != nil {
+			return "", fmt.Errorf("copy %s: %w", name, err)
+		}
+	}
+	return parsed.EffectiveRoot(destDir), nil
+}
+
+// downloadDirectURL fetches a non-GitHub URL and extracts zip or tar.gz into destDir.
+func downloadDirectURL(rawURL, destDir string, client *http.Client) (effectiveRoot string, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return "", fmt.Errorf("unsupported scheme %q (use https or http)", u.Scheme)
+	}
+	resp, err := client.Get(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("download failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("download failed: %s", resp.Status)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+	if len(data) == 0 {
+		return "", errors.New("download returned empty body")
+	}
+	ct := strings.ToLower(strings.TrimSpace(resp.Header.Get("Content-Type")))
+	pathLower := strings.ToLower(u.Path)
+	isZip := strings.Contains(ct, "zip") || strings.HasSuffix(pathLower, ".zip")
+	isGzip := strings.Contains(ct, "gzip") || strings.HasSuffix(pathLower, ".gz") || strings.HasSuffix(pathLower, ".tgz")
+
+	if isZip {
+		effectiveRoot, err = extractZip(data, destDir)
+		if err != nil {
+			return "", fmt.Errorf("extract zip: %w", err)
+		}
+		return effectiveRoot, nil
+	}
+	if isGzip || (len(data) >= 2 && data[0] == 0x1f && data[1] == 0x8b) {
+		effectiveRoot, err = extractTarGz(data, destDir)
+		if err != nil {
+			return "", fmt.Errorf("extract tar.gz: %w", err)
+		}
+		return effectiveRoot, nil
+	}
+	if effectiveRoot, err = extractZip(data, destDir); err == nil {
+		return effectiveRoot, nil
+	}
+	if effectiveRoot, err = extractTarGz(data, destDir); err == nil {
+		return effectiveRoot, nil
+	}
+	return "", fmt.Errorf("unsupported archive format (expected zip or tar.gz); Content-Type: %q", ct)
+}
+
+// DownloadURL downloads from any supported URL and extracts the archive to destDir.
+// Returns the effective root path where extracted content lives (single top-level dir if present, else destDir).
+// Supports:
+//   - GitHub tree URLs: https://github.com/<owner>/<repo>/tree/<branch>/<path> (fetches GitHub archive zip).
+//   - Direct URLs to a .zip or .tar.gz/.tgz archive; the response body is extracted as-is.
+//
+// destDir must exist. If the download or extraction fails, returns an error.
+func DownloadURL(rawURL, destDir string, client *http.Client) (effectiveRoot string, err error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", errors.New("URL is required")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: DefaultDownloadTimeout}
+	}
+	if _, parseErr := ParseGitHubTreeURL(rawURL); parseErr == nil {
+		return DownloadGitHubTree(rawURL, destDir, client)
+	}
+	return downloadDirectURL(rawURL, destDir, client)
+}
+
+// extractZip extracts zip data into destDir and returns the effective root
+// (single top-level directory if present, else destDir).
+func extractZip(data []byte, destDir string) (effectiveRoot string, err error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", fmt.Errorf("open zip: %w", err)
+	}
+	destDirClean := filepath.Clean(destDir)
+	var topLevel string
+	for _, f := range zr.File {
+		name := f.Name
+		if f.FileInfo().IsDir() {
+			name = strings.TrimSuffix(name, "/")
+			if name == "" {
+				continue
+			}
+			dstPath, err := safeJoinPath(destDirClean, name)
+			if err != nil {
+				return "", err
+			}
+			if err := os.MkdirAll(dstPath, 0750); err != nil {
+				return "", fmt.Errorf("mkdir %s: %w", dstPath, err)
+			}
+			if topLevel == "" && !strings.Contains(name, "/") {
+				topLevel = name
+			}
+			continue
+		}
+		dstPath, err := safeJoinPath(destDirClean, name)
+		if err != nil {
+			return "", err
+		}
+		if err := os.MkdirAll(filepath.Dir(dstPath), 0750); err != nil {
+			return "", fmt.Errorf("mkdir parent of %s: %w", dstPath, err)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return "", fmt.Errorf("open zip entry %s: %w", name, err)
+		}
+		dst, err := os.Create(dstPath) // #nosec G304 -- dstPath from safeJoinPath
+		if err != nil {
+			_ = rc.Close()
+			return "", fmt.Errorf("create %s: %w", dstPath, err)
+		}
+		_, err = io.Copy(dst, rc) // #nosec G110 -- size bounded by client timeout and typical archive size
+		_ = dst.Close()
+		_ = rc.Close()
+		if err != nil {
+			return "", fmt.Errorf("copy %s: %w", name, err)
+		}
+		firstSegment := strings.SplitN(name, "/", 2)[0]
+		if topLevel == "" {
+			topLevel = firstSegment
+		} else if topLevel != firstSegment {
+			topLevel = "" // multiple top-level entries
+		}
+	}
+	if topLevel != "" {
+		return filepath.Join(destDir, topLevel), nil
+	}
+	return destDir, nil
+}
+
+// extractTarGz extracts gzip-compressed tar data into destDir and returns the effective root.
+func extractTarGz(data []byte, destDir string) (effectiveRoot string, err error) {
+	gr, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("open gzip: %w", err)
+	}
+	defer gr.Close()
+	destDirClean := filepath.Clean(destDir)
+	tr := tar.NewReader(gr)
+	var topLevel string
+	for {
+		header, err := tr.Next()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return "", fmt.Errorf("read tar: %w", err)
+		}
+		name := strings.TrimPrefix(filepath.Clean(header.Name), ".")
+		name = strings.TrimPrefix(name, "/")
+		if name == "" {
+			continue
+		}
+		dstPath, err := safeJoinPath(destDirClean, name)
+		if err != nil {
+			return "", err
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dstPath, 0750); err != nil {
+				return "", fmt.Errorf("mkdir %s: %w", dstPath, err)
+			}
+			first := strings.SplitN(name, string(filepath.Separator), 2)[0]
+			if topLevel == "" {
+				topLevel = first
+			} else if topLevel != first {
+				topLevel = "" // multiple roots
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(dstPath), 0750); err != nil {
+				return "", fmt.Errorf("mkdir parent of %s: %w", dstPath, err)
+			}
+			outFile, err := os.Create(dstPath) // #nosec G304 -- dstPath from safeJoinPath
+			if err != nil {
+				return "", fmt.Errorf("create %s: %w", dstPath, err)
+			}
+			_, err = io.Copy(outFile, tr) // #nosec G110 -- size bounded by client timeout and typical archive size
+			_ = outFile.Close()
+			if err != nil {
+				return "", fmt.Errorf("copy %s: %w", name, err)
+			}
+			first := strings.SplitN(name, string(filepath.Separator), 2)[0]
+			if topLevel == "" {
+				topLevel = first
+			} else if topLevel != first {
+				topLevel = ""
+			}
+		default:
+			// skip symlinks, etc.
+		}
+	}
+	if topLevel != "" {
+		return filepath.Join(destDir, topLevel), nil
+	}
+	return destDir, nil
+}
+
+// ValidateConfigurationRoot checks that source-crs and CRSPath exist under root.
+func ValidateConfigurationRoot(root string) error {
+	sourceCRS := filepath.Join(root, SourceCRSPath)
+	crsPath := filepath.Join(root, CRSPath)
+	if _, err := os.Stat(sourceCRS); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("configuration root missing %s (path: %s)", SourceCRSPath, sourceCRS)
+		}
+		return fmt.Errorf("stat %s: %w", sourceCRS, err)
+	}
+	if _, err := os.Stat(crsPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("configuration root missing %s (path: %s)", CRSPath, crsPath)
+		}
+		return fmt.Errorf("stat %s: %w", crsPath, err)
+	}
+	return nil
+}

--- a/pkg/rdsdiff/download_test.go
+++ b/pkg/rdsdiff/download_test.go
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/sakhoury/kube-compare-mcp/pkg/rdsdiff"
+)
+
+var _ = Describe("rdsdiff download", func() {
+	Describe("ParseGitHubTreeURL", func() {
+		It("parses full URL with path", func() {
+			u, err := rdsdiff.ParseGitHubTreeURL("https://github.com/openshift-kni/telco-reference/tree/konflux-telco-core-rds-4-20/telco-ran/configuration")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u.Owner).To(Equal("openshift-kni"))
+			Expect(u.Repo).To(Equal("telco-reference"))
+			Expect(u.Branch).To(Equal("konflux-telco-core-rds-4-20"))
+			Expect(u.Path).To(Equal("telco-ran/configuration"))
+			Expect(u.ArchiveURL()).To(Equal("https://github.com/openshift-kni/telco-reference/archive/refs/heads/konflux-telco-core-rds-4-20.zip"))
+			Expect(u.TopLevelDir()).To(Equal("telco-reference-konflux-telco-core-rds-4-20"))
+		})
+		It("parses URL with branch only", func() {
+			u, err := rdsdiff.ParseGitHubTreeURL("https://github.com/org/repo/tree/main")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u.Owner).To(Equal("org"))
+			Expect(u.Repo).To(Equal("repo"))
+			Expect(u.Branch).To(Equal("main"))
+			Expect(u.Path).To(Equal(""))
+		})
+		It("rejects empty URL", func() {
+			_, err := rdsdiff.ParseGitHubTreeURL("")
+			Expect(err).To(HaveOccurred())
+		})
+		It("rejects non-GitHub URL", func() {
+			_, err := rdsdiff.ParseGitHubTreeURL("https://gitlab.com/org/repo/-/tree/branch/path")
+			Expect(err).To(HaveOccurred())
+		})
+		It("rejects URL without tree", func() {
+			_, err := rdsdiff.ParseGitHubTreeURL("https://github.com/org/repo")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ValidateConfigurationRoot", func() {
+		It("returns error when source-crs missing", func() {
+			root, _ := os.MkdirTemp("", "rds-validate")
+			defer os.RemoveAll(root)
+			Expect(os.MkdirAll(filepath.Join(root, rdsdiff.CRSPath), 0750)).To(Succeed())
+			err := rdsdiff.ValidateConfigurationRoot(root)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("source-crs"))
+		})
+		It("returns error when CRSPath missing", func() {
+			root, _ := os.MkdirTemp("", "rds-validate")
+			defer os.RemoveAll(root)
+			Expect(os.MkdirAll(filepath.Join(root, rdsdiff.SourceCRSPath), 0750)).To(Succeed())
+			err := rdsdiff.ValidateConfigurationRoot(root)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(rdsdiff.CRSPath))
+		})
+		It("succeeds when both exist", func() {
+			root, _ := os.MkdirTemp("", "rds-validate")
+			defer os.RemoveAll(root)
+			Expect(os.MkdirAll(filepath.Join(root, rdsdiff.SourceCRSPath), 0750)).To(Succeed())
+			Expect(os.MkdirAll(filepath.Join(root, rdsdiff.CRSPath), 0750)).To(Succeed())
+			err := rdsdiff.ValidateConfigurationRoot(root)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("DownloadURL", func() {
+		It("returns error for empty URL", func() {
+			dir, _ := os.MkdirTemp("", "rds-download")
+			defer os.RemoveAll(dir)
+			_, err := rdsdiff.DownloadURL("", dir, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("URL is required"))
+		})
+		It("returns error for unsupported scheme", func() {
+			dir, _ := os.MkdirTemp("", "rds-download")
+			defer os.RemoveAll(dir)
+			_, err := rdsdiff.DownloadURL("ftp://example.com/archive.zip", dir, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported scheme"))
+		})
+	})
+})
+
+var _ = Describe("rdsdiff storage", func() {
+	Describe("SessionDir", func() {
+		It("creates session dir under workDir", func() {
+			workDir, _ := os.MkdirTemp("", "rds-work")
+			defer os.RemoveAll(workDir)
+			sessionDir, err := rdsdiff.SessionDir(workDir, "req-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sessionDir).To(HavePrefix(workDir))
+			Expect(sessionDir).To(ContainSubstring("rds-diff-req-1"))
+			info, err := os.Stat(sessionDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.IsDir()).To(BeTrue())
+		})
+		It("uses temp dir when workDir empty", func() {
+			sessionDir, err := rdsdiff.SessionDir("", "req-2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sessionDir).NotTo(BeEmpty())
+			Expect(sessionDir).To(ContainSubstring("rds-diff-req-2"))
+		})
+	})
+})

--- a/pkg/rdsdiff/policygen.go
+++ b/pkg/rdsdiff/policygen.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// RunPolicyGen copies source-crs into CRSPath under configRoot, runs the PolicyGenerator binary
+// for each SNO policy file, and writes generated YAMLs to generatedDir.
+// configRoot is the effective configuration root (e.g. .../telco-ran/configuration).
+// policyGeneratorPath is the path to the PolicyGenerator binary (e.g. from ACM or ztp-site-generate image).
+// PolicyGenerator accepts config file path(s) as positional args and writes generated policies to stdout.
+func RunPolicyGen(configRoot, policyGeneratorPath, generatedDir string) error {
+	configRoot = filepath.Clean(configRoot)
+	generatedDir = filepath.Clean(generatedDir)
+	sourceCRS := filepath.Join(configRoot, SourceCRSPath)
+	crsPathDir := filepath.Join(configRoot, CRSPath)
+	if err := os.MkdirAll(generatedDir, 0750); err != nil {
+		return fmt.Errorf("mkdir generated dir: %w", err)
+	}
+	// Copy source-crs into CRSPath so PolicyGenerator finds it
+	destSourceCRS := filepath.Join(crsPathDir, "source-crs")
+	if err := os.RemoveAll(destSourceCRS); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove dest source-crs: %w", err)
+	}
+	if err := copyDir(sourceCRS, destSourceCRS); err != nil {
+		return fmt.Errorf("copy source-crs to %s: %w", destSourceCRS, err)
+	}
+	// Run PolicyGenerator for each policy file; CWD = crsPathDir so relative paths resolve.
+	// PolicyGenerator [flags] <policy-generator-config-file>... writes generated YAML to stdout.
+	for _, policyFile := range ListOfCRsForSNO {
+		policyPath := filepath.Join(crsPathDir, policyFile)
+		if _, err := os.Stat(policyPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return fmt.Errorf("stat %s: %w", policyPath, err)
+		}
+		cmd := exec.Command(policyGeneratorPath, policyPath) // #nosec G204 -- paths from config root and our binary path
+		cmd.Dir = crsPathDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("policyGenerator %s: %w\n%s", policyFile, err, string(out))
+		}
+		// Write stdout to a file in generatedDir (name stem + -generated.yaml to avoid overwriting config)
+		base := strings.TrimSuffix(policyFile, filepath.Ext(policyFile))
+		outPath := filepath.Join(generatedDir, base+"-generated.yaml")
+		if err := os.WriteFile(outPath, out, 0600); err != nil {
+			return fmt.Errorf("write PolicyGenerator output %s: %w", outPath, err)
+		}
+	}
+	return nil
+}
+
+func copyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("read dir %s: %w", src, err)
+	}
+	if err := os.MkdirAll(dst, 0750); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dst, err)
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+			continue
+		}
+		data, err := os.ReadFile(srcPath) // #nosec G304 -- srcPath from Join(src, e.Name()), our dir
+		if err != nil {
+			return fmt.Errorf("read %s: %w", srcPath, err)
+		}
+		if err := os.WriteFile(dstPath, data, 0600); err != nil { // #nosec G703 -- dstPath from Join(dst, e.Name()), our dir
+			return fmt.Errorf("write %s: %w", dstPath, err)
+		}
+	}
+	return nil
+}

--- a/pkg/rdsdiff/rdsdiff_suite_test.go
+++ b/pkg/rdsdiff/rdsdiff_suite_test.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRdsdiff(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rdsdiff Suite")
+}

--- a/pkg/rdsdiff/storage.go
+++ b/pkg/rdsdiff/storage.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rdsdiff
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// SessionDir creates a session directory under workDir and returns its path.
+// workDir defaults to os.TempDir() if empty. Session name is rds-diff-<requestID>-<timestamp>.
+func SessionDir(workDir, requestID string) (string, error) {
+	if workDir == "" {
+		workDir = os.TempDir()
+	}
+	workDir = filepath.Clean(workDir)
+	if err := os.MkdirAll(workDir, 0750); err != nil {
+		return "", fmt.Errorf("mkdir work dir: %w", err)
+	}
+	name := fmt.Sprintf("rds-diff-%s-%d", requestID, time.Now().Unix())
+	sessionPath := filepath.Join(workDir, name)
+	if err := os.MkdirAll(sessionPath, 0750); err != nil {
+		return "", fmt.Errorf("mkdir session: %w", err)
+	}
+	return sessionPath, nil
+}

--- a/pkg/rdsdiff/storage.go
+++ b/pkg/rdsdiff/storage.go
@@ -3,9 +3,11 @@
 package rdsdiff
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -23,6 +25,52 @@ func SessionDir(workDir, requestID string) (string, error) {
 	sessionPath := filepath.Join(workDir, name)
 	if err := os.MkdirAll(sessionPath, 0750); err != nil {
 		return "", fmt.Errorf("mkdir session: %w", err)
+	}
+	return sessionPath, nil
+}
+
+// SessionID returns the session directory name (last path component) for use as a stable artifact ID.
+func SessionID(sessionPath string) string {
+	return filepath.Base(sessionPath)
+}
+
+// ErrInvalidSessionID is returned when the session ID is invalid (e.g. path traversal).
+var ErrInvalidSessionID = errors.New("invalid session id")
+
+// ResolveSessionPath resolves workDir + sessionID to an absolute session path and validates that it
+// is under workDir and exists as a directory. sessionID must be a single path segment (no slashes or "..").
+func ResolveSessionPath(workDir, sessionID string) (sessionPath string, err error) {
+	workDir = filepath.Clean(workDir)
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return "", ErrInvalidSessionID
+	}
+	cleaned := filepath.Clean(sessionID)
+	if cleaned != sessionID || strings.Contains(sessionID, "..") || filepath.IsAbs(sessionID) {
+		return "", ErrInvalidSessionID
+	}
+	if filepath.Separator != '/' && strings.ContainsRune(sessionID, filepath.Separator) {
+		return "", ErrInvalidSessionID
+	}
+	sessionPath = filepath.Join(workDir, sessionID)
+	absWork, _ := filepath.Abs(workDir)
+	absSession, _ := filepath.Abs(sessionPath)
+	rel, err := filepath.Rel(absWork, absSession)
+	if err != nil {
+		return "", fmt.Errorf("resolve session path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", ErrInvalidSessionID
+	}
+	info, err := os.Stat(sessionPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("stat session: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("not a directory: %s", sessionPath)
 	}
 	return sessionPath, nil
 }


### PR DESCRIPTION
### One line description
This PR introduces new MCP tool, that allows agents to list differences between RDS versions.

### How it works
The tools expects two URLs for RDS sources, it downloads the sources,
run the PolictyGenerator binary on them, compare, and return a report
with the differences between the given versions.

Agents can also provide a directory path on which the tool will store all generated/extracted CRs so the agents will be able to process them for future work.

NOTE:
At the moment the tool can perform diffs only for telco-ran RDS

Signed-off-by: Talor Itzhak <titzhak@redhat.com>