### PR TITLE
deps: update Go toolchain to 1.25.9 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/sakhoury/kube-compare-mcp
 
-go 1.25.6
-
-toolchain go1.25.7
+go 1.25.9
 
 require (
 	github.com/adrg/strutil v0.3.1


### PR DESCRIPTION
govulncheck flagged CVEs in crypto/x509, crypto/tls, archive/tar, os, and net/url — all fixed in go1.25.9.