### PR TITLE
fix: make optional schema fields accept null for LLM client compatibility

### DIFF
--- a/pkg/mcpserver/schema.go
+++ b/pkg/mcpserver/schema.go
@@ -26,6 +26,7 @@ func ClusterDiffInputSchema() *jsonschema.Schema {
 		prop.Default = json.RawMessage(`"json"`)
 	}
 
+	makeOptionalFieldsNullable(schema)
 	return schema
 }
 
@@ -42,6 +43,7 @@ func ResolveRDSInputSchema() *jsonschema.Schema {
 		prop.Enum = []any{"core", "ran"}
 	}
 
+	makeOptionalFieldsNullable(schema)
 	return schema
 }
 
@@ -64,6 +66,7 @@ func ValidateRDSInputSchema() *jsonschema.Schema {
 		prop.Default = json.RawMessage(`"json"`)
 	}
 
+	makeOptionalFieldsNullable(schema)
 	return schema
 }
 
@@ -102,6 +105,7 @@ func BIOSDiffInputSchema() *jsonschema.Schema {
 		prop.Default = json.RawMessage(`"json"`)
 	}
 
+	makeOptionalFieldsNullable(schema)
 	return schema
 }
 
@@ -125,4 +129,24 @@ func BIOSDiffOutputSchema() *jsonschema.Schema {
 	}
 
 	return schema
+}
+
+// makeOptionalFieldsNullable makes non-required fields accept null values in
+// addition to their declared type. LLM clients often send "field": null instead
+// of omitting optional fields, which fails strict JSON schema validation.
+func makeOptionalFieldsNullable(schema *jsonschema.Schema) {
+	required := make(map[string]bool, len(schema.Required))
+	for _, r := range schema.Required {
+		required[r] = true
+	}
+
+	for name, prop := range schema.Properties {
+		if required[name] {
+			continue
+		}
+		if prop.Type != "" {
+			prop.Types = []string{prop.Type, "null"}
+			prop.Type = ""
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add `makeOptionalFieldsNullable()` utility to `schema.go` that allows non-required fields to accept `null` in addition to their declared type
- Apply it to all 4 existing tool input schemas (`ClusterDiffInput`, `ResolveRDSInput`, `ValidateRDSInput`, `BIOSDiffInput`)
- LLM clients (Claude, GPT, etc.) often send `"field": null` instead of omitting optional fields, which fails strict JSON schema validation in the MCP SDK

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/mcpserver/...` passes
- [ ] Verify MCP tool calls with null optional fields are accepted by the server

Inspired by a pattern in #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)