### PR TITLE
security: add SSRF protection using doyensec/safeurl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.9
 
 require (
 	github.com/adrg/strutil v0.3.1
+	github.com/doyensec/safeurl v0.2.2
 	github.com/google/go-containerregistry v0.21.5
 	github.com/google/jsonschema-go v0.4.2
 	github.com/modelcontextprotocol/go-sdk v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/docker/cli v29.4.0+incompatible h1:+IjXULMetlvWJiuSI0Nbor36lcJ5BTcVpU
 github.com/docker/cli v29.4.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.3 h1:gAm/VtF9wgqJMoxzT3Gj5p4AqIjCBS4wrsOh9yRqcz8=
 github.com/docker/docker-credential-helpers v0.9.3/go.mod h1:x+4Gbw9aGmChi3qTLZj8Dfn0TD20M/fuWy0E5+WDeCo=
+github.com/doyensec/safeurl v0.2.2 h1:+sFUqwOnqqmtUAC85/sGdOKfJh8zOacyghkaLzsOk40=
+github.com/doyensec/safeurl v0.2.2/go.mod h1:3H0cgRpPYPSpgxRRn5yGD35Ns/LgGX/BVWSBbzUqXtY=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=

--- a/pkg/mcpserver/cluster_diff.go
+++ b/pkg/mcpserver/cluster_diff.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/doyensec/safeurl"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -105,18 +106,23 @@ type CompareService struct {
 }
 
 // NewCompareService creates a new CompareService with default implementations.
+// The HTTP client uses doyensec/safeurl for SSRF protection, blocking requests to private/internal networks.
 func NewCompareService() *CompareService {
+	cfg := safeurl.GetConfigBuilder().
+		SetTimeout(getHTTPValidationTimeout()).
+		EnableIPv6(true).
+		SetAllowedPorts(80, 443, 8080, 8443).
+		SetCheckRedirect(func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("too many redirects")
+			}
+			return nil
+		}).
+		Build()
+
 	return &CompareService{
-		HTTPClient: &DefaultHTTPDoer{Client: &http.Client{
-			Timeout: getHTTPValidationTimeout(),
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				if len(via) >= 10 {
-					return errors.New("too many redirects")
-				}
-				return nil
-			},
-		}},
-		Registry: DefaultRegistry,
+		HTTPClient: safeurl.Client(cfg),
+		Registry:   DefaultRegistry,
 	}
 }
 
@@ -273,6 +279,33 @@ func ClassifyReference(ref string) ReferenceType {
 	return ReferenceTypeLocal
 }
 
+// safeURLErrorMessage translates safeurl-specific errors into user-friendly security messages.
+func safeURLErrorMessage(err error, refURL string) (string, bool) {
+	var ipErr *safeurl.AllowedIPError
+	var portErr *safeurl.AllowedPortError
+	var schemeErr *safeurl.AllowedSchemeError
+	var hostErr *safeurl.AllowedHostError
+	var invalidHostErr *safeurl.InvalidHostError
+	var credsErr *safeurl.SendingCredentialsBlockedError
+
+	switch {
+	case errors.As(err, &ipErr):
+		return fmt.Sprintf("the URL '%s' resolves to a private/internal network address and was blocked for security (SSRF protection)", refURL), true
+	case errors.As(err, &portErr):
+		return fmt.Sprintf("the URL '%s' uses a non-standard port that is not allowed", refURL), true
+	case errors.As(err, &schemeErr):
+		return fmt.Sprintf("the URL '%s' uses a disallowed scheme; only http:// and https:// are allowed", refURL), true
+	case errors.As(err, &hostErr):
+		return fmt.Sprintf("the host in URL '%s' is not allowed", refURL), true
+	case errors.As(err, &invalidHostErr):
+		return fmt.Sprintf("the URL '%s' has an invalid or empty host", refURL), true
+	case errors.As(err, &credsErr):
+		return fmt.Sprintf("the URL '%s' contains embedded credentials which are not allowed", refURL), true
+	default:
+		return "", false
+	}
+}
+
 const defaultHTTPValidationTimeout = 10 * time.Second
 
 // getHTTPValidationTimeout returns the timeout for HTTP reference validation.
@@ -311,6 +344,11 @@ func (s *CompareService) ValidateHTTPReference(ctx context.Context, refURL strin
 	if err != nil {
 		if ctx.Err() != nil {
 			return NewCompareError("validate", ErrContextCanceled, "The validation was canceled")
+		}
+
+		if msg, ok := safeURLErrorMessage(err, refURL); ok {
+			return NewSecurityError("ssrf-blocked", msg,
+				"Only publicly accessible HTTP/HTTPS URLs on standard ports (80, 443, 8080, 8443) are allowed as references")
 		}
 
 		return NewCompareError("validate",

--- a/pkg/mcpserver/cluster_diff_test.go
+++ b/pkg/mcpserver/cluster_diff_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"time"
 
@@ -259,35 +258,53 @@ var _ = Describe("CompareHandler", func() {
 	})
 
 	Describe("HTTP Validation Integration", func() {
-		var server *httptest.Server
-
-		AfterEach(func() {
-			if server != nil {
-				server.Close()
-			}
+		It("blocks requests to loopback IPs (SSRF protection)", func() {
+			service := mcpserver.NewCompareService()
+			err := service.ValidateHTTPReference(context.Background(), "http://127.0.0.1:80/metadata.yaml")
+			Expect(err).To(HaveOccurred())
+			var secErr *mcpserver.SecurityError
+			Expect(errors.As(err, &secErr)).To(BeTrue())
+			Expect(secErr.Code).To(Equal("ssrf-blocked"))
+			Expect(secErr.Message).To(ContainSubstring("private"))
 		})
 
-		It("validates live HTTP endpoint successfully", func() {
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				Expect(r.Method).To(Equal(http.MethodHead))
-				w.WriteHeader(http.StatusOK)
-			}))
-
+		It("blocks requests to private network IPs (SSRF protection)", func() {
 			service := mcpserver.NewCompareService()
-			err := service.ValidateHTTPReference(context.Background(), server.URL)
-			Expect(err).NotTo(HaveOccurred())
+			err := service.ValidateHTTPReference(context.Background(), "http://10.0.0.1:80/metadata.yaml")
+			Expect(err).To(HaveOccurred())
+			var secErr *mcpserver.SecurityError
+			Expect(errors.As(err, &secErr)).To(BeTrue())
+			Expect(secErr.Code).To(Equal("ssrf-blocked"))
+		})
+
+		It("blocks requests to non-standard ports", func() {
+			service := mcpserver.NewCompareService()
+			err := service.ValidateHTTPReference(context.Background(), "http://example.com:9999/metadata.yaml")
+			Expect(err).To(HaveOccurred())
+			var secErr *mcpserver.SecurityError
+			Expect(errors.As(err, &secErr)).To(BeTrue())
+			Expect(secErr.Code).To(Equal("ssrf-blocked"))
 		})
 
 		It("handles timeout correctly", func() {
-			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				time.Sleep(100 * time.Millisecond)
-			}))
-
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 			defer cancel()
 
-			service := mcpserver.NewCompareService()
-			err := service.ValidateHTTPReference(ctx, server.URL)
+			ctrl := gomock.NewController(GinkgoT())
+			defer ctrl.Finish()
+			mockHTTP := NewMockHTTPDoer(ctrl)
+			mockHTTP.EXPECT().
+				Do(gomock.Any()).
+				DoAndReturn(func(req *http.Request) (*http.Response, error) {
+					time.Sleep(100 * time.Millisecond)
+					return nil, context.DeadlineExceeded
+				})
+
+			service := &mcpserver.CompareService{
+				HTTPClient: mockHTTP,
+				Registry:   NewMockRegistryClient(ctrl),
+			}
+			err := service.ValidateHTTPReference(ctx, "http://example.com/metadata.yaml")
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/pkg/mcpserver/interfaces.go
+++ b/pkg/mcpserver/interfaces.go
@@ -124,20 +124,6 @@ func (f *DefaultClusterClientFactory) NewClient(config *rest.Config) (ClusterCli
 	return &DefaultClusterClient{client: dynClient}, nil
 }
 
-// DefaultHTTPDoer is the production implementation of HTTPDoer using http.Client.
-type DefaultHTTPDoer struct {
-	Client *http.Client
-}
-
-// Do performs an HTTP request using the underlying http.Client.
-func (d *DefaultHTTPDoer) Do(req *http.Request) (*http.Response, error) {
-	resp, err := d.Client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("http request failed: %w", err)
-	}
-	return resp, nil
-}
-
 // Package-level default implementations for production use.
 // These can be overridden in tests.
 var (


### PR DESCRIPTION
## Summary

- Integrate [doyensec/safeurl](https://github.com/doyensec/safeurl) to block HTTP requests to private/internal network addresses, mitigating [gosec G107 (SSRF via taint analysis)](https://github.com/sakhoury/kube-compare-mcp/security/code-scanning/7)
- Add typed error detection for safeurl-specific errors, returning clear `SecurityError` messages instead of generic "remote unreachable"
- Remove unused `DefaultHTTPDoer` struct (replaced by `safeurl.WrappedClient` which satisfies `HTTPDoer` directly)

### How it works

The `safeurl` library validates resolved IPs at connection time via `syscall.RawConn` control hooks, covering 40+ private CIDR ranges (RFC 1918, loopback, link-local, IPv6) with built-in DNS rebinding protection. The HTTP client in `NewCompareService()` is configured with:

- **IP blocking**: All private/internal ranges (127.0.0.0/8, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, IPv6 equivalents, and more)
- **Port allowlist**: 80, 443, 8080, 8443
- **IPv6 enabled**: Prevents bypass via IPv6 link-local addresses
- **Redirect limit**: Max 10 redirects preserved from previous implementation

### Files changed

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | Added `github.com/doyensec/safeurl v0.2.2` |
| `pkg/mcpserver/cluster_diff.go` | Replaced `http.Client` with `safeurl.Client()`; added `safeURLErrorMessage()` for typed error detection |
| `pkg/mcpserver/cluster_diff_test.go` | SSRF tests with `SecurityError` type assertions for loopback, private IP, and port blocking |
| `pkg/mcpserver/interfaces.go` | Removed dead `DefaultHTTPDoer` struct |

## Test plan

- [x] `make test` — 276/276 specs pass
- [x] `make lint` — 0 issues
- [x] Verify loopback IP (127.0.0.1) requests are blocked with `SecurityError`
- [x] Verify private network IP (10.0.0.1) requests are blocked with `SecurityError`
- [x] Verify non-standard port (9999) requests are blocked with `SecurityError`
- [x] Verify timeout handling still works correctly via mock
- [x] Verify existing mock-based HTTP validation tests unaffected

Resolves https://github.com/sakhoury/kube-compare-mcp/security/code-scanning/7